### PR TITLE
Implement DelTable

### DIFF
--- a/nftables.go
+++ b/nftables.go
@@ -329,6 +329,21 @@ func (cc *Conn) FlushRuleset() {
 	})
 }
 
+// DelTable deletes a specific table, along with all chains/rules it contains.
+func (cc *Conn) DelTable(t *Table) {
+	data := cc.marshalAttr([]netlink.Attribute{
+		{Type: unix.NFTA_TABLE_NAME, Data: []byte(t.Name + "\x00")},
+		{Type: unix.NFTA_TABLE_FLAGS, Data: []byte{0, 0, 0, 0}},
+	})
+	cc.messages = append(cc.messages, netlink.Message{
+		Header: netlink.Header{
+			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELTABLE),
+			Flags: netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge,
+		},
+		Data: append(extraHeader(uint8(t.Family), 0), data...),
+	})
+}
+
 // AddTable adds the specified Table. See also
 // https://wiki.nftables.org/wiki-nftables/index.php/Configuring_tables
 func (cc *Conn) AddTable(t *Table) *Table {


### PR DESCRIPTION
Using my googley github account cuz CLABot.

Background: Am working on a namespace-based thingy to sandbox processes. I'm creating a veth for each 'box' and punting one end into the processes' network namespace. I'm using nftables to NAT the traffic, so I create a table for each box.

When the process completes and is torn down, its best to cleanup the rules used for the now-deleted IP addresses, hence the implementation of `DelTable`.

I determined the netlink packet structure by looking at `libnftnl` source (specifically `nft_ruleset_table_build_msg`, which converts a 'flush' command into `NFT_MSG_DEL*` commands based on the information provided. Given how simple it is I havent put in any tests.