### PR TITLE
Add support for inverted set lookups.

### DIFF
--- a/expr/lookup.go
+++ b/expr/lookup.go
@@ -29,6 +29,7 @@ type Lookup struct {
 
 	SetID   uint32
 	SetName string
+	Invert  bool
 }
 
 func (e *Lookup) marshal() ([]byte, error) {
@@ -39,6 +40,9 @@ func (e *Lookup) marshal() ([]byte, error) {
 	}
 	if e.DestRegister != 0 {
 		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_LOOKUP_DREG, Data: binaryutil.BigEndian.PutUint32(e.DestRegister)})
+	}
+	if e.Invert {
+		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_LOOKUP_FLAGS, Data: binaryutil.BigEndian.PutUint32(unix.NFT_LOOKUP_F_INV)})
 	}
 	opAttrs = append(opAttrs,
 		netlink.Attribute{Type: unix.NFTA_LOOKUP_SET, Data: []byte(e.SetName + "\x00")},


### PR DESCRIPTION
Sorry for missing this, I meant this to go in the last PR. Fortunately its only 4 lines xD

Tested in production.

The if statement is necessary, as having a flags attribute without that bit set is illegal: https://github.com/torvalds/linux/blob/49a57857aeea06ca831043acbb0fa5e0f50602fd/net/netfilter/nft_lookup.c#L90