### PR TITLE
Add logic for regular chains

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -92,7 +92,7 @@ func (cc *Conn) AddChain(c *Chain) *Chain {
 		{Type: unix.NFTA_CHAIN_NAME, Data: []byte(c.Name + "\x00")},
 	})
 
-	if c.Hooknum != 0 {
+	if c.Type != "" {
 		chainHook := cc.marshalAttr([]netlink.Attribute{
 			{Type: unix.NFTA_HOOK_HOOKNUM, Data: binaryutil.BigEndian.PutUint32(uint32(c.Hooknum))},
 			{Type: unix.NFTA_HOOK_PRIORITY, Data: binaryutil.BigEndian.PutUint32(uint32(c.Priority))},


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>
Closes: #27 

With this PR I was able to create these chains and jump:
```
<pre>table ip ipv4table {
	set ipv4rule-1 {
		type inet_service
		flags constant
		elements = { 12000 }
	}

	chain ipv4chain-1 {
		type filter hook input priority 0; policy accept;
		tcp dport @ipv4rule-1 jump ipv4chain-3
	}

	chain ipv4chain-2 {
	}

	chain ipv4chain-3 {
	}
```