### PR TITLE
Additional change to Element to support set intervals

### DIFF
--- a/set.go
+++ b/set.go
@@ -99,14 +99,14 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 func (s *Set) makeElemList(vals []SetElement) ([]netlink.Attribute, error) {
 	var elements []netlink.Attribute
 	for i, v := range vals {
-		encodedKey, err := netlink.MarshalAttributes([]netlink.Attribute{{Type: unix.NFTA_DATA_VALUE, Data: v.Key}})
+		encodedKey, err := netlink.MarshalAttributes([]netlink.Attribute{{Type: unix.NFTA_DATA_VALUE /* unix.NFTA_SET_ELEM_KEY*/, Data: v.Key}})
 		if err != nil {
 			return nil, fmt.Errorf("marshal key %d: %v", i, err)
 		}
 		item := []netlink.Attribute{{Type: unix.NFTA_SET_ELEM_KEY | unix.NLA_F_NESTED, Data: encodedKey}}
 
 		if len(v.Val) > 0 {
-			encodedVal, err := netlink.MarshalAttributes([]netlink.Attribute{{Type: unix.NFTA_DATA_VALUE, Data: v.Val}})
+			encodedVal, err := netlink.MarshalAttributes([]netlink.Attribute{{Type: unix.NFTA_DATA_VALUE /*unix.NFTA_SET_ELEM_DATA*/, Data: v.Val}})
 			if err != nil {
 				return nil, fmt.Errorf("marshal item %d: %v", i, err)
 			}

--- a/set.go
+++ b/set.go
@@ -101,12 +101,12 @@ func (s *Set) makeElemList(vals []SetElement) ([]netlink.Attribute, error) {
 	var elements []netlink.Attribute
 
 	for i, v := range vals {
+		item := make([]netlink.Attribute, 0)
 		var flags uint32
 		if v.IntervalEnd {
 			flags |= unix.NFT_SET_ELEM_INTERVAL_END
+			item = append(item, netlink.Attribute{Type: unix.NFTA_SET_ELEM_FLAGS, Data: binaryutil.BigEndian.PutUint32(flags)})
 		}
-
-		item := []netlink.Attribute{{Type: unix.NFTA_SET_ELEM_FLAGS, Data: binaryutil.BigEndian.PutUint32(flags)}}
 
 		encodedKey, err := netlink.MarshalAttributes([]netlink.Attribute{{Type: unix.NFTA_SET_ELEM_KEY, Data: v.Key}})
 		if err != nil {


### PR DESCRIPTION
I also did a little bit of Set and Element flags cleanup to be consistent.

With this PR, something like that becomes possible :)
```
 table ip ipv4table {
	set fcc16889cb72 {
		type ipv4_addr
		flags constant,interval
		elements = { 10.16.0.0/16, 192.16.0.0/16 }
	}

	chain ipv4chain-1 {
		type filter hook input priority filter; policy accept;
		ip daddr @fcc16889cb72 return comment "V"
	}
}
```