### PR TITLE
lookup dest reg check fix

### DIFF
--- a/expr/lookup.go
+++ b/expr/lookup.go
@@ -26,6 +26,7 @@ import (
 type Lookup struct {
 	SourceRegister uint32
 	DestRegister   uint32
+	IsDestRegSet   bool
 
 	SetID   uint32
 	SetName string
@@ -38,7 +39,7 @@ func (e *Lookup) marshal() ([]byte, error) {
 	if e.SourceRegister != 0 {
 		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_LOOKUP_SREG, Data: binaryutil.BigEndian.PutUint32(e.SourceRegister)})
 	}
-	if e.DestRegister != 0 {
+	if e.IsDestRegSet {
 		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_LOOKUP_DREG, Data: binaryutil.BigEndian.PutUint32(e.DestRegister)})
 	}
 	if e.Invert {


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently to check if Lookup's DesReg is set, it is compared against 0. In some cases it is not valid, example when Lookup refers to map or vmap it explicitly sets Lookup DestReg but because of the check, this attribute does not get added to the message. This PR introduces a bool var indicating whether DestReg is set or not.