### PR TITLE
Fix anonymous set creation

### DIFF
--- a/set.go
+++ b/set.go
@@ -334,10 +334,6 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	// Set the values of the set if initial values were provided.
 	if len(vals) > 0 {
 		hdrType := unix.NFT_MSG_NEWSETELEM
-		if s.Anonymous {
-			// Anonymous sets can only be populated within NEWSET.
-			hdrType = unix.NFT_MSG_NEWSET
-		}
 		elements, err := s.makeElemList(vals)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

When I tried to create an anonymous set with a rule, the rule creation was failing and dmesg showed this error. 

```
106145.361517] netlink: 'mimic-nat': attribute type 3 has an invalid length.
```
Then I compared what we do to create anonymous set and what nft cli does, it appears nft uses 
```
{len=92, type=NFNL_SUBSYS_NFTABLES<<8|NFT_MSG_NEWSETELEM, flags=NLM_F_REQUEST|NLM_F_CREATE, seq=1, pid=0}
```
Where nftables code was attempting to create elements inside of NEW_SET. Once check for anonymous set was removed, creation of anonymous started working:
```
	chain KUBE-SVC-57XVOCFNTLTR3Q27 {
		numgen random mod 2 vmap { 0 : jump KUBE-SEP-FS3FUULGZPVD4VYB, 1 : jump KUBE-SEP-MMFZROQSLQ3DKOQA }
	}
```