### PR TITLE
Replace %v with %w to wrap netlink error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 
 language: go
 go:
-  - "1.10"
+  - "1.13"
 
 script:
   # Check whether files are syntactically correct.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - "gofmt -l $(find . -name '*.go' | tr '\\n' ' ') >/dev/null"
   # Check whether files were not gofmt'ed.
   - "gosrc=$(find . -name '*.go' | tr '\\n' ' '); [ $(gofmt -l $gosrc 2>&- | wc -l) -eq 0 ] || (echo 'gofmt was not run on these files:'; gofmt -l $gosrc 2>&-; false)"
-  - go tool vet .
+  - go vet .
   - go test ./...
   - go test -c github.com/google/nftables
   - sudo ./nftables.test -test.v -run_system_tests

--- a/conn.go
+++ b/conn.go
@@ -57,11 +57,11 @@ func (cc *Conn) Flush() error {
 	defer conn.Close()
 
 	if _, err := conn.SendMessages(batch(cc.messages)); err != nil {
-		return fmt.Errorf("SendMessages: %v", err)
+		return fmt.Errorf("SendMessages: %w", err)
 	}
 
 	if _, err := conn.Receive(); err != nil {
-		return fmt.Errorf("Receive: %v", err)
+		return fmt.Errorf("Receive: %w", err)
 	}
 
 	cc.messages = nil


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>
When netlink returns error and that error bubbles up to the client code it is difficult to parse it. With `%w` the error can be unwrapped and checked.