### PR TITLE
Flush fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 
 language: go
 go:
-  - "1.10"
+  - "1.13"
 
 script:
   # Check whether files are syntactically correct.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - "gofmt -l $(find . -name '*.go' | tr '\\n' ' ') >/dev/null"
   # Check whether files were not gofmt'ed.
   - "gosrc=$(find . -name '*.go' | tr '\\n' ' '); [ $(gofmt -l $gosrc 2>&- | wc -l) -eq 0 ] || (echo 'gofmt was not run on these files:'; gofmt -l $gosrc 2>&-; false)"
-  - go tool vet .
+  - go vet .
   - go test ./...
   - go test -c github.com/google/nftables
   - sudo ./nftables.test -test.v -run_system_tests

--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,10 @@ type Conn struct {
 // Flush sends all buffered commands in a single batch to nftables.
 func (cc *Conn) Flush() error {
 	cc.Lock()
-	defer cc.Unlock()
+	defer func() {
+		cc.messages = nil
+		cc.Unlock()
+	}()
 	if len(cc.messages) == 0 {
 		// Messages were already programmed, returning nil
 		return nil
@@ -61,10 +64,8 @@ func (cc *Conn) Flush() error {
 	}
 
 	if _, err := conn.Receive(); err != nil {
-		return fmt.Errorf("Receive: %w", err)
+		return fmt.Errorf("Receive:  %w", err)
 	}
-
-	cc.messages = nil
 
 	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -57,11 +57,11 @@ func (cc *Conn) Flush() error {
 	defer conn.Close()
 
 	if _, err := conn.SendMessages(batch(cc.messages)); err != nil {
-		return fmt.Errorf("SendMessages: %v", err)
+		return fmt.Errorf("SendMessages: %w", err)
 	}
 
 	if _, err := conn.Receive(); err != nil {
-		return fmt.Errorf("Receive: %v", err)
+		return fmt.Errorf("Receive: %w", err)
 	}
 
 	cc.messages = nil


### PR DESCRIPTION
Currently when conn.Receive() returns error,  Flush() just returns an error to the caller without cleaning messages queue. As a result all subsequent call will fail as the messages queue still contains message generating an error.  This PR proposes to clean the messages queue on success and on failure and let the caller to deal with retries logic.