### PR TITLE
Set the rule handle after flush

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -123,7 +123,7 @@ func (cc *Conn) AddChain(c *Chain) *Chain {
 			{Type: unix.NFTA_CHAIN_TYPE, Data: []byte(c.Type + "\x00")},
 		})...)
 	}
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWCHAIN),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -144,7 +144,7 @@ func (cc *Conn) DelChain(c *Chain) {
 		{Type: unix.NFTA_CHAIN_NAME, Data: []byte(c.Name + "\x00")},
 	})
 
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELCHAIN),
 			Flags: netlink.Request | netlink.Acknowledge,
@@ -162,7 +162,7 @@ func (cc *Conn) FlushChain(c *Chain) {
 		{Type: unix.NFTA_RULE_TABLE, Data: []byte(c.Table.Name + "\x00")},
 		{Type: unix.NFTA_RULE_CHAIN, Data: []byte(c.Name + "\x00")},
 	})
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
 			Flags: netlink.Request | netlink.Acknowledge,

--- a/chain.go
+++ b/chain.go
@@ -123,7 +123,7 @@ func (cc *Conn) AddChain(c *Chain) *Chain {
 			{Type: unix.NFTA_CHAIN_TYPE, Data: []byte(c.Type + "\x00")},
 		})...)
 	}
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWCHAIN),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -144,7 +144,7 @@ func (cc *Conn) DelChain(c *Chain) {
 		{Type: unix.NFTA_CHAIN_NAME, Data: []byte(c.Name + "\x00")},
 	})
 
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELCHAIN),
 			Flags: netlink.Request | netlink.Acknowledge,
@@ -162,7 +162,7 @@ func (cc *Conn) FlushChain(c *Chain) {
 		{Type: unix.NFTA_RULE_TABLE, Data: []byte(c.Table.Name + "\x00")},
 		{Type: unix.NFTA_RULE_CHAIN, Data: []byte(c.Name + "\x00")},
 	})
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
 			Flags: netlink.Request | netlink.Acknowledge,

--- a/conn.go
+++ b/conn.go
@@ -106,7 +106,6 @@ func (cc *Conn) Flush() error {
 func (cc *Conn) PutMessage(msg netlink.Message) int32 {
 	if cc.messages == nil {
 		cc.messages = make([]netlink.Message, 128)
-		cc.messages = append(cc.messages, netlink.Message{})
 		cc.messages[0] = netlink.Message{
 			Header: netlink.Header{
 				Type:  netlink.HeaderType(unix.NFNL_MSG_BATCH_BEGIN),

--- a/conn.go
+++ b/conn.go
@@ -118,7 +118,6 @@ func (cc *Conn) PutMessage(msg netlink.Message) int32 {
 
 	i := atomic.AddInt32(&cc.it, 1)
 
-	cc.messages = append(cc.messages, netlink.Message{})
 	cc.messages[i] = msg
 
 	return i

--- a/conn.go
+++ b/conn.go
@@ -78,7 +78,7 @@ func (cc *Conn) Flush() error {
 	}
 
 	// Trigger entities callback
-	for checkReceive(conn) {
+	for cc.checkReceive(conn) {
 		rmsg, err := conn.Receive()
 
 		if err != nil {
@@ -95,7 +95,11 @@ func (cc *Conn) Flush() error {
 	return nil
 }
 
-func checkReceive(c *netlink.Conn) bool {
+func (cc *Conn) checkReceive(c *netlink.Conn) bool {
+	if cc.TestDial != nil {
+		return false
+	}
+
 	sc, err := c.SyscallConn()
 
 	var n int

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.12
 
 require (
 	github.com/koneu/natend v0.0.0-20150829182554-ec0926ea948d
-	github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b
+	github.com/mdlayher/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 // indirect
-	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c
+	golang.org/x/sys v0.0.0-20200106114638-5f8ca72cd632
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/koneu/natend v0.0.0-20150829182554-ec0926ea948d/go.mod h1:QHb4k4cr1fQ
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
 github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b h1:W3er9pI7mt2gOqOWzwvx20iJ8Akiqz1mUMTxU6wdvl8=
 github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
+github.com/mdlayher/netlink v1.0.0 h1:vySPY5Oxnn/8lxAPn2cK6kAzcZzYJl3KriSLO46OT18=
+github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -25,4 +27,6 @@ golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c h1:S/FtSvpNLtFBgjTqcKsRpsa6a
 golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea h1:Mz1TMnfJDRJLk8S8OPCoJYgrsp/Se/2TBre2+vwX128=
 golang.org/x/sys v0.0.0-20191113150313-8ad342257130 h1:+sdNBpwFF05NvMnEyGynbOs/Gr2LQwORWEPKXuEXxzU=
+golang.org/x/sys v0.0.0-20200106114638-5f8ca72cd632 h1:ateQkYCVYo8UwIBvoR3zj1Dh2K6Op/n3GxemXfB44/Y=
+golang.org/x/sys v0.0.0-20200106114638-5f8ca72cd632/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -4068,11 +4068,11 @@ func TestHandleBack(t *testing.T) {
 	rulesGetted2, _ := c.GetRule(filter, chain2)
 
 	if len(rulesGetted1) != len(rulesCreated1) {
-		t.Fatalf("Bad ruleset lenght got %d want %d", len(rulesGetted1), len(rulesCreated1))
+		t.Fatalf("Bad ruleset length got %d want %d", len(rulesGetted1), len(rulesCreated1))
 	}
 
 	if len(rulesGetted2) != len(rulesCreated2) {
-		t.Fatalf("Bad ruleset lenght got %d want %d", len(rulesGetted2), len(rulesCreated2))
+		t.Fatalf("Bad ruleset length got %d want %d", len(rulesGetted2), len(rulesCreated2))
 	}
 
 	for i, r := range rulesGetted1 {

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -4033,13 +4033,13 @@ func TestIntegrationAddRule(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			if r.Handle == 0 {
+				t.Fatalf("handle value is empty at %d", i)
+			}
+
 			rulesGetted, _ := c.GetRule(filter, chain)
 
 			for i, rg := range rulesGetted {
-				if r.Handle == 0 {
-					t.Fatalf("handle value is empty at %d", i)
-				}
-
 				if bytes.Equal(rg.UserData, r.UserData) && rg.Handle != r.Handle {
 					t.Fatalf("mismatched handle at %d-%d, got: %d, want: %d", w, i, r.Handle, rg.Handle)
 				}

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -3983,6 +3983,10 @@ func TestStatelessNAT(t *testing.T) {
 
 func TestHandleBack(t *testing.T) {
 
+	if os.Getenv("TRAVIS") == "true" {
+		t.SkipNow()
+	}
+
 	// Create a new network namespace to test these operations,
 	// and tear down the namespace at test completion.
 	c, newNS := openSystemNFTConn(t)

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -3982,11 +3982,7 @@ func TestStatelessNAT(t *testing.T) {
 	}
 }
 
-func TestHandleBack(t *testing.T) {
-
-	if os.Getenv("TRAVIS") == "true" {
-		t.SkipNow()
-	}
+func TestIntegrationAddRule(t *testing.T) {
 
 	// Create a new network namespace to test these operations,
 	// and tear down the namespace at test completion.

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -4008,7 +4008,6 @@ func TestIntegrationAddRule(t *testing.T) {
 	c.Flush()
 
 	execN := func(w int, n int) {
-
 		c := &nftables.Conn{NetNS: int(newNS)}
 
 		for i := 0; i < n; i++ {

--- a/obj.go
+++ b/obj.go
@@ -43,7 +43,7 @@ func (cc *Conn) AddObj(o Obj) Obj {
 		return nil
 	}
 
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWOBJ),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,

--- a/obj.go
+++ b/obj.go
@@ -43,7 +43,7 @@ func (cc *Conn) AddObj(o Obj) Obj {
 		return nil
 	}
 
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWOBJ),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,

--- a/rule.go
+++ b/rule.go
@@ -130,6 +130,8 @@ func (cc *Conn) AddRule(r *Rule) *Rule {
 		Data: append(extraHeader(uint8(r.Table.Family), 0), msgData...),
 	})
 
+	cc.rules = append(cc.rules, r)
+
 	return r
 }
 

--- a/rule.go
+++ b/rule.go
@@ -130,7 +130,7 @@ func (cc *Conn) AddRule(r *Rule) *Rule {
 		Data: append(extraHeader(uint8(r.Table.Family), 0), msgData...),
 	}
 
-	i := cc.PutMessage(m)
+	i := cc.putMessage(m)
 	cc.PutEntity(i, r)
 
 	return r
@@ -152,7 +152,7 @@ func (cc *Conn) DelRule(r *Rule) error {
 	})...)
 	flags := netlink.Request | netlink.Acknowledge
 
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
 			Flags: flags,
@@ -166,10 +166,11 @@ func (cc *Conn) DelRule(r *Rule) error {
 // HandleResponse retrieves Handle in netlink response
 func (r *Rule) HandleResponse(msg netlink.Message) {
 	rule, err := ruleFromMsg(msg)
-
-	if err == nil {
-		r.Handle = rule.Handle
+	if err != nil {
+		return
 	}
+
+	r.Handle = rule.Handle
 }
 
 func exprsFromMsg(b []byte) ([]expr.Any, error) {

--- a/rule.go
+++ b/rule.go
@@ -130,7 +130,11 @@ func (cc *Conn) AddRule(r *Rule) *Rule {
 		Data: append(extraHeader(uint8(r.Table.Family), 0), msgData...),
 	})
 
-	cc.rules = append(cc.rules, r)
+	if cc.rules == nil {
+		cc.rules = make(map[int]*Rule)
+	}
+
+	cc.rules[len(cc.messages)] = r
 
 	return r
 }

--- a/rule.go
+++ b/rule.go
@@ -130,11 +130,11 @@ func (cc *Conn) AddRule(r *Rule) *Rule {
 		Data: append(extraHeader(uint8(r.Table.Family), 0), msgData...),
 	})
 
-	if cc.rules == nil {
-		cc.rules = make(map[int]*Rule)
+	if cc.entities == nil {
+		cc.entities = make(map[int]Entity)
 	}
 
-	cc.rules[len(cc.messages)] = r
+	cc.entities[len(cc.messages)] = r
 
 	return r
 }
@@ -164,6 +164,15 @@ func (cc *Conn) DelRule(r *Rule) error {
 	})
 
 	return nil
+}
+
+// HandleResponse retrieves Handle in netlink response
+func (r *Rule) HandleResponse(msg netlink.Message) {
+	rule, err := ruleFromMsg(msg)
+
+	if err == nil {
+		r.Handle = rule.Handle
+	}
 }
 
 func exprsFromMsg(b []byte) ([]expr.Any, error) {

--- a/rule.go
+++ b/rule.go
@@ -122,19 +122,16 @@ func (cc *Conn) AddRule(r *Rule) *Rule {
 		flags = netlink.Request | netlink.Acknowledge | netlink.Create | unix.NLM_F_ECHO | unix.NLM_F_APPEND
 	}
 
-	cc.messages = append(cc.messages, netlink.Message{
+	m := netlink.Message{
 		Header: netlink.Header{
 			Type:  ruleHeaderType,
 			Flags: flags,
 		},
 		Data: append(extraHeader(uint8(r.Table.Family), 0), msgData...),
-	})
-
-	if cc.entities == nil {
-		cc.entities = make(map[int]Entity)
 	}
 
-	cc.entities[len(cc.messages)] = r
+	i := cc.PutMessage(m)
+	cc.PutEntity(i, r)
 
 	return r
 }
@@ -155,7 +152,7 @@ func (cc *Conn) DelRule(r *Rule) error {
 	})...)
 	flags := netlink.Request | netlink.Acknowledge
 
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
 			Flags: flags,

--- a/set.go
+++ b/set.go
@@ -165,7 +165,7 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 	if err != nil {
 		return err
 	}
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWSETELEM),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -327,7 +327,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 			netlink.Attribute{Type: unix.NFTA_SET_USERDATA, Data: []byte("\x00\x04\x02\x00\x00\x00")})
 	}
 
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWSET),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -342,7 +342,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 		if err != nil {
 			return err
 		}
-		cc.messages = append(cc.messages, netlink.Message{
+		cc.PutMessage(netlink.Message{
 			Header: netlink.Header{
 				Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | hdrType),
 				Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -362,7 +362,7 @@ func (cc *Conn) DelSet(s *Set) {
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
 	})
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSET),
 			Flags: netlink.Request | netlink.Acknowledge,
@@ -383,7 +383,7 @@ func (cc *Conn) SetDeleteElements(s *Set, vals []SetElement) error {
 	if err != nil {
 		return err
 	}
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSETELEM),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -402,7 +402,7 @@ func (cc *Conn) FlushSet(s *Set) {
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
 	})
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSETELEM),
 			Flags: netlink.Request | netlink.Acknowledge,

--- a/set.go
+++ b/set.go
@@ -165,7 +165,7 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 	if err != nil {
 		return err
 	}
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWSETELEM),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -327,7 +327,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 			netlink.Attribute{Type: unix.NFTA_SET_USERDATA, Data: []byte("\x00\x04\x02\x00\x00\x00")})
 	}
 
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWSET),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -342,7 +342,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 		if err != nil {
 			return err
 		}
-		cc.PutMessage(netlink.Message{
+		cc.putMessage(netlink.Message{
 			Header: netlink.Header{
 				Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | hdrType),
 				Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -362,7 +362,7 @@ func (cc *Conn) DelSet(s *Set) {
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
 	})
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSET),
 			Flags: netlink.Request | netlink.Acknowledge,
@@ -383,7 +383,7 @@ func (cc *Conn) SetDeleteElements(s *Set, vals []SetElement) error {
 	if err != nil {
 		return err
 	}
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSETELEM),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -402,7 +402,7 @@ func (cc *Conn) FlushSet(s *Set) {
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
 	})
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSETELEM),
 			Flags: netlink.Request | netlink.Acknowledge,

--- a/table.go
+++ b/table.go
@@ -53,7 +53,7 @@ func (cc *Conn) DelTable(t *Table) {
 		{Type: unix.NFTA_TABLE_NAME, Data: []byte(t.Name + "\x00")},
 		{Type: unix.NFTA_TABLE_FLAGS, Data: []byte{0, 0, 0, 0}},
 	})
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELTABLE),
 			Flags: netlink.Request | netlink.Acknowledge,
@@ -71,7 +71,7 @@ func (cc *Conn) AddTable(t *Table) *Table {
 		{Type: unix.NFTA_TABLE_NAME, Data: []byte(t.Name + "\x00")},
 		{Type: unix.NFTA_TABLE_FLAGS, Data: []byte{0, 0, 0, 0}},
 	})
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWTABLE),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -89,7 +89,7 @@ func (cc *Conn) FlushTable(t *Table) {
 	data := cc.marshalAttr([]netlink.Attribute{
 		{Type: unix.NFTA_RULE_TABLE, Data: []byte(t.Name + "\x00")},
 	})
-	cc.messages = append(cc.messages, netlink.Message{
+	cc.PutMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
 			Flags: netlink.Request | netlink.Acknowledge,

--- a/table.go
+++ b/table.go
@@ -53,7 +53,7 @@ func (cc *Conn) DelTable(t *Table) {
 		{Type: unix.NFTA_TABLE_NAME, Data: []byte(t.Name + "\x00")},
 		{Type: unix.NFTA_TABLE_FLAGS, Data: []byte{0, 0, 0, 0}},
 	})
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELTABLE),
 			Flags: netlink.Request | netlink.Acknowledge,
@@ -71,7 +71,7 @@ func (cc *Conn) AddTable(t *Table) *Table {
 		{Type: unix.NFTA_TABLE_NAME, Data: []byte(t.Name + "\x00")},
 		{Type: unix.NFTA_TABLE_FLAGS, Data: []byte{0, 0, 0, 0}},
 	})
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWTABLE),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
@@ -89,7 +89,7 @@ func (cc *Conn) FlushTable(t *Table) {
 	data := cc.marshalAttr([]netlink.Attribute{
 		{Type: unix.NFTA_RULE_TABLE, Data: []byte(t.Name + "\x00")},
 	})
-	cc.PutMessage(netlink.Message{
+	cc.putMessage(netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
 			Flags: netlink.Request | netlink.Acknowledge,


### PR DESCRIPTION
Currently this very basic and useful workflow is not possible:

```go
r1 := c.AddRule(&nftables.Rule{
	Table: filter,
	Chain: prerouting,
	Exprs: []expr.Any{
		&expr.Verdict{
			// [ immediate reg 0 drop ]
			Kind: expr.VerdictDrop,
		},
	},
})

c.Flush()

c.DelRule(r1)

c.Flush()

```

The solution:
Because of ``NLM_F_ECHO`` all netlink messages in the transaction are returned back. In the case of rules, there are returned back with Handle. Rules are linked to requests by keeping the index of netlink request of a rule. We rely on sequence number to retrieve the right request when receiving a netlink response.

What does the solution allow?
- Manipulating rules without fetching and processing rules before
- Adding comment to rules, because we don't need user data to retrieve rules anymore
