### PR TITLE
Add set's id to newsetelem message

### DIFF
--- a/set.go
+++ b/set.go
@@ -161,7 +161,7 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 		return errors.New("anonymous sets cannot be updated")
 	}
 
-	elements, err := s.makeElemList(vals)
+	elements, err := s.makeElemList(vals, s.ID)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 	return nil
 }
 
-func (s *Set) makeElemList(vals []SetElement) ([]netlink.Attribute, error) {
+func (s *Set) makeElemList(vals []SetElement, id uint32) ([]netlink.Attribute, error) {
 	var elements []netlink.Attribute
 
 	for i, v := range vals {
@@ -248,7 +248,8 @@ func (s *Set) makeElemList(vals []SetElement) ([]netlink.Attribute, error) {
 
 	return []netlink.Attribute{
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
-		{Type: unix.NFTA_SET_KEY_TYPE, Data: binaryutil.BigEndian.PutUint32(unix.NFTA_DATA_VALUE)},
+		//		{Type: unix.NFTA_SET_KEY_TYPE, Data: binaryutil.BigEndian.PutUint32(unix.NFTA_DATA_VALUE)},
+		{Type: unix.NFTA_SET_KEY_TYPE, Data: binaryutil.BigEndian.PutUint32(id)},
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_ELEM_LIST_ELEMENTS | unix.NLA_F_NESTED, Data: encodedElem},
 	}, nil
@@ -338,7 +339,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	// Set the values of the set if initial values were provided.
 	if len(vals) > 0 {
 		hdrType := unix.NFT_MSG_NEWSETELEM
-		elements, err := s.makeElemList(vals)
+		elements, err := s.makeElemList(vals, s.ID)
 		if err != nil {
 			return err
 		}
@@ -379,7 +380,7 @@ func (cc *Conn) SetDeleteElements(s *Set, vals []SetElement) error {
 		return errors.New("anonymous sets cannot be updated")
 	}
 
-	elements, err := s.makeElemList(vals)
+	elements, err := s.makeElemList(vals, s.ID)
 	if err != nil {
 		return err
 	}

--- a/set.go
+++ b/set.go
@@ -248,7 +248,6 @@ func (s *Set) makeElemList(vals []SetElement, id uint32) ([]netlink.Attribute, e
 
 	return []netlink.Attribute{
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
-		//		{Type: unix.NFTA_SET_KEY_TYPE, Data: binaryutil.BigEndian.PutUint32(unix.NFTA_DATA_VALUE)},
 		{Type: unix.NFTA_SET_KEY_TYPE, Data: binaryutil.BigEndian.PutUint32(id)},
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_ELEM_LIST_ELEMENTS | unix.NLA_F_NESTED, Data: encodedElem},

--- a/set.go
+++ b/set.go
@@ -248,7 +248,7 @@ func (s *Set) makeElemList(vals []SetElement, id uint32) ([]netlink.Attribute, e
 
 	return []netlink.Attribute{
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
-		{Type: unix.NFTA_SET_KEY_TYPE, Data: binaryutil.BigEndian.PutUint32(id)},
+		{Type: unix.NFTA_LOOKUP_SET_ID, Data: binaryutil.BigEndian.PutUint32(id)},
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_ELEM_LIST_ELEMENTS | unix.NLA_F_NESTED, Data: encodedElem},
 	}, nil


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Set's ID must be provided in new_set_elem message. See below, two anonymous sets of exactly the same type and number of elements are created: First anonymous set has id of 1 and second has id of 2.  IDs are programmed in 02572 message which is `type=NFNL_SUBSYS_NFTABLES<<8|NFT_MSG_NEWSETELEM`

```
----------------	------------------
|  0000000188  |	| message length |
| 02572 | R--- |	|  type | flags  |
|  0000000001  |	| sequence number|
|  0000000000  |	|     port ID    |
----------------	------------------
| 02 00 00 00  |	|  extra header  |
|00012|--|00002|	|len |flags| type|
| 5f 5f 6d 61  |	|      data      |	 _ _ m a
| 70 25 64 00  |	|      data      |	 p % d  
|00008|--|00004|	|len |flags| type|
| 00 00 00 01  |	|      data      |	     < ---------------------- ID 1
|00014|--|00001|	|len |flags| type|
| 69 70 76 34  |	|      data      |	 i p v 4
| 74 61 62 6c  |	|      data      |	 t a b l
| 65 00 00 00  |	|      data      |	 e      


----------------	------------------
|  0000000188  |	| message length |
| 02572 | R--- |	|  type | flags  |
|  0000000001  |	| sequence number|
|  0000000000  |	|     port ID    |
----------------	------------------
| 02 00 00 00  |	|  extra header  |
|00012|--|00002|	|len |flags| type|
| 5f 5f 6d 61  |	|      data      |	 _ _ m a
| 70 25 64 00  |	|      data      |	 p % d  
|00008|--|00004|	|len |flags| type|
| 00 00 00 02  |	|      data      |	   < ---------------------- ID 2
|00014|--|00001|	|len |flags| type|
| 69 70 76 34  |	|      data      |	 i p v 4
| 74 61 62 6c  |	|      data      |	 t a b l
| 65 00 00 00  |	|      data      |	 e      

```
