### PR TITLE
GetSets/SetAddElements fixes

### DIFF
--- a/nftables_test.go
+++ b/nftables_test.go
@@ -1677,6 +1677,56 @@ func TestCreateUseNamedSet(t *testing.T) {
 	}
 }
 
+func TestIP6SetAddElements(t *testing.T) {
+
+	// Create a new network namespace to test these operations,
+	// and tear down the namespace at test completion.
+	c, newNS := openSystemNFTConn(t)
+	defer cleanupSystemNFTConn(t, newNS)
+	// Clear all rules at the beginning + end of the test.
+	c.FlushRuleset()
+	defer c.FlushRuleset()
+
+	filter := c.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyIPv6,
+		Name:   "filter",
+	})
+	portSet := &nftables.Set{
+		Table:   filter,
+		Name:    "ports",
+		KeyType: nftables.TypeInetService,
+	}
+	if err := c.AddSet(portSet, nil); err != nil {
+		t.Errorf("c.AddSet(portSet) failed: %v", err)
+	}
+	if err := c.SetAddElements(portSet, []nftables.SetElement{
+		{Key: binaryutil.BigEndian.PutUint16(22)},
+		{Key: binaryutil.BigEndian.PutUint16(80)},
+	}); err != nil {
+		t.Errorf("c.SetVal(portSet) failed: %v", err)
+	}
+
+	if err := c.Flush(); err != nil {
+		t.Errorf("c.Flush() failed: %v", err)
+	}
+
+	sets, err := c.GetSets(filter)
+	if err != nil {
+		t.Errorf("c.GetSets() failed: %v", err)
+	}
+	if len(sets) != 1 {
+		t.Fatalf("len(sets) = %d, want 1", len(sets))
+	}
+
+	elements, err := c.GetSetElements(sets[0])
+	if err != nil {
+		t.Errorf("c.GetSetElements(portSet) failed: %v", err)
+	}
+	if len(elements) != 2 {
+		t.Fatalf("len(portSetElements) = %d, want 2", len(sets))
+	}
+}
+
 func TestCreateDeleteNamedSet(t *testing.T) {
 	// Create a new network namespace to test these operations,
 	// and tear down the namespace at test completion.

--- a/set.go
+++ b/set.go
@@ -559,6 +559,7 @@ func (cc *Conn) GetSets(t *Table) ([]*Set, error) {
 		if err != nil {
 			return nil, err
 		}
+		s.Table = &Table{Name: t.Name, Use: t.Use, Flags: t.Flags, Family: t.Family}
 		sets = append(sets, s)
 	}
 

--- a/set.go
+++ b/set.go
@@ -170,7 +170,7 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWSETELEM),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
 		},
-		Data: append(extraHeader(unix.NFTA_SET_NAME, 0), cc.marshalAttr(elements)...),
+		Data: append(extraHeader(uint8(s.Table.Family), 0), cc.marshalAttr(elements)...),
 	})
 
 	return nil


### PR DESCRIPTION
I made 2 minor changes:

SetAddElements used to write a constant value (corresponding to IPv4) into the family field of the header. I changed that to use the family of the set's table to allow access to set's in non IPv4-tables.

The sets returned by GetSets used to never have their table set (resulting in a panic if using these sets in almost any other function, as these need the table's name and family). I added a copy of the table passed to GetSets to each set returned.

I also added a test for those changes.