### PR TITLE
Fix obj api

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -41,6 +41,10 @@ func (c *CounterObj) unmarshal(ad *netlink.AttributeDecoder) error {
 	return ad.Err()
 }
 
+func (c *CounterObj) table() *Table {
+	return c.Table
+}
+
 func (c *CounterObj) family() TableFamily {
 	return c.Table.Family
 }

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -1252,7 +1252,7 @@ func TestGetObjReset(t *testing.T) {
 	}
 
 	filter := &nftables.Table{Name: "filter", Family: nftables.TableFamilyIPv4}
-	obj, err := c.ResetObj(&nftables.CounterObj{
+	obj, err := c.ResetObject(&nftables.CounterObj{
 		Table: filter,
 		Name:  "fwded",
 	})
@@ -1347,30 +1347,30 @@ func TestObjAPI(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	objs, err := c.GetObjs(table)
+	objs, err := c.GetObjects(table)
 
 	if err != nil {
-		t.Errorf("c.GetObjs(table) failed: %v failed", err)
+		t.Errorf("c.GetObjects(table) failed: %v failed", err)
 	}
 
 	if got := len(objs); got != 2 {
 		t.Fatalf("unexpected number of objects: got %d, want %d", got, 2)
 	}
 
-	objsOther, err := c.GetObjs(tableOther)
+	objsOther, err := c.GetObjects(tableOther)
 
 	if err != nil {
-		t.Errorf("c.GetObjs(tableOther) failed: %v failed", err)
+		t.Errorf("c.GetObjects(tableOther) failed: %v failed", err)
 	}
 
 	if got := len(objsOther); got != 1 {
 		t.Fatalf("unexpected number of objects: got %d, want %d", got, 1)
 	}
 
-	obj1, err := c.GetObj(counter1)
+	obj1, err := c.GetObject(counter1)
 
 	if err != nil {
-		t.Errorf("c.GetObj(counter1) failed: %v failed", err)
+		t.Errorf("c.GetObject(counter1) failed: %v failed", err)
 	}
 
 	rcounter1, ok := obj1.(*nftables.CounterObj)
@@ -1383,10 +1383,10 @@ func TestObjAPI(t *testing.T) {
 		t.Fatalf("unexpected counter name: got %s, want %s", rcounter1.Name, "fwded1")
 	}
 
-	obj2, err := c.GetObj(counter2)
+	obj2, err := c.GetObject(counter2)
 
 	if err != nil {
-		t.Errorf("c.GetObj(counter2) failed: %v failed", err)
+		t.Errorf("c.GetObject(counter2) failed: %v failed", err)
 	}
 
 	rcounter2, ok := obj2.(*nftables.CounterObj)
@@ -1399,30 +1399,50 @@ func TestObjAPI(t *testing.T) {
 		t.Fatalf("unexpected counter name: got %s, want %s", rcounter2.Name, "fwded2")
 	}
 
-	_, err = c.ResetObj(counter1)
+	_, err = c.ResetObject(counter1)
 
 	if err != nil {
-		t.Errorf("c.ResetObjs(table) failed: %v failed", err)
+		t.Errorf("c.ResetObjects(table) failed: %v failed", err)
 	}
 
-	obj1, err = c.GetObj(counter1)
+	obj1, err = c.GetObject(counter1)
 
 	if err != nil {
-		t.Errorf("c.GetObj(counter1) failed: %v failed", err)
+		t.Errorf("c.GetObject(counter1) failed: %v failed", err)
 	}
 
 	if counter1 := obj1.(*nftables.CounterObj); counter1.Packets > 0 {
 		t.Errorf("unexpected packets number: got %d, want %d", counter1.Packets, 0)
 	}
 
-	obj2, err = c.GetObj(counter2)
+	obj2, err = c.GetObject(counter2)
 
 	if err != nil {
-		t.Errorf("c.GetObj(counter2) failed: %v failed", err)
+		t.Errorf("c.GetObject(counter2) failed: %v failed", err)
 	}
 
 	if counter2 := obj2.(*nftables.CounterObj); counter2.Packets != 1 {
 		t.Errorf("unexpected packets number: got %d, want %d", counter2.Packets, 1)
+	}
+
+	legacy, err := c.GetObj(counter1)
+	
+	if err != nil {
+		t.Errorf("c.GetObj(counter1) failed: %v failed", err)
+	}
+
+	if len(legacy) != 2 {
+		t.Errorf("unexpected number of objects: got %d, want %d", len(legacy), 2)
+	}
+
+	legacyReset, err := c.GetObjReset(counter1)
+
+	if err != nil {
+		t.Errorf("c.GetObjReset(counter1) failed: %v failed", err)
+	}
+
+	if len(legacyReset) != 2 {
+		t.Errorf("unexpected number of objects: got %d, want %d", len(legacyReset), 2)
 	}
 
 }

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -1426,7 +1426,7 @@ func TestObjAPI(t *testing.T) {
 	}
 
 	legacy, err := c.GetObj(counter1)
-	
+
 	if err != nil {
 		t.Errorf("c.GetObj(counter1) failed: %v failed", err)
 	}

--- a/obj.go
+++ b/obj.go
@@ -66,7 +66,6 @@ func (cc *Conn) GetObjReset(o Obj) ([]Obj, error) {
 	return cc.getObj(nil, o.table(), unix.NFT_MSG_GETOBJ_RESET)
 }
 
-
 // GetObject gets the specified Object
 func (cc *Conn) GetObject(o Obj) (Obj, error) {
 	objs, err := cc.getObj(o, o.table(), unix.NFT_MSG_GETOBJ)

--- a/obj.go
+++ b/obj.go
@@ -27,6 +27,7 @@ var objHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.N
 // Obj represents a netfilter stateful object. See also
 // https://wiki.nftables.org/wiki-nftables/index.php/Stateful_objects
 type Obj interface {
+	table() *Table
 	family() TableFamily
 	unmarshal(*netlink.AttributeDecoder) error
 	marshal(data bool) ([]byte, error)
@@ -54,13 +55,23 @@ func (cc *Conn) AddObj(o Obj) Obj {
 }
 
 // GetObj gets the specified Obj without resetting it.
-func (cc *Conn) GetObj(o Obj) ([]Obj, error) {
-	return cc.getObj(o, unix.NFT_MSG_GETOBJ)
+func (cc *Conn) GetObj(o Obj) (Obj, error) {
+	objs, err := cc.getObj(o, o.table(), unix.NFT_MSG_GETOBJ)
+	return objs[0], err
+}
+
+func (cc *Conn) GetObjs(t *Table) ([]Obj, error) {
+	return cc.getObj(nil, t, unix.NFT_MSG_GETOBJ)
 }
 
 // GetObjReset gets the specified Obj and resets it.
-func (cc *Conn) GetObjReset(o Obj) ([]Obj, error) {
-	return cc.getObj(o, unix.NFT_MSG_GETOBJ_RESET)
+func (cc *Conn) ResetObj(o Obj) (Obj, error) {
+	objs, err := cc.getObj(o, o.table(), unix.NFT_MSG_GETOBJ_RESET)
+	return objs[0], err
+}
+
+func (cc *Conn) ResetObjs(t *Table) ([]Obj, error) {
+	return cc.getObj(nil, t, unix.NFT_MSG_GETOBJ_RESET)
 }
 
 func objFromMsg(msg netlink.Message) (Obj, error) {
@@ -112,24 +123,35 @@ func objFromMsg(msg netlink.Message) (Obj, error) {
 	return nil, fmt.Errorf("malformed stateful object")
 }
 
-func (cc *Conn) getObj(o Obj, msgType uint16) ([]Obj, error) {
+func (cc *Conn) getObj(o Obj, t *Table, msgType uint16) ([]Obj, error) {
 	conn, err := cc.dialNetlink()
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
 
-	data, err := o.marshal(false)
-	if err != nil {
-		return nil, err
+	var data []byte
+	var message netlink.Message
+	var flags netlink.HeaderFlags
+
+	if o != nil {
+		data, err = o.marshal(false)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		flags = netlink.Dump
+		data, err = netlink.MarshalAttributes([]netlink.Attribute{
+			{Type: unix.NFTA_RULE_TABLE, Data: []byte(t.Name + "\x00")},
+		})
 	}
 
-	message := netlink.Message{
+	message = netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | msgType),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Dump,
+			Flags: netlink.Request | netlink.Acknowledge | flags,
 		},
-		Data: append(extraHeader(uint8(o.family()), 0), data...),
+		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	}
 
 	if _, err := conn.SendMessages([]netlink.Message{message}); err != nil {

--- a/set.go
+++ b/set.go
@@ -161,7 +161,7 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 		return errors.New("anonymous sets cannot be updated")
 	}
 
-	elements, err := s.makeElemList(vals)
+	elements, err := s.makeElemList(vals, s.ID)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func (cc *Conn) SetAddElements(s *Set, vals []SetElement) error {
 	return nil
 }
 
-func (s *Set) makeElemList(vals []SetElement) ([]netlink.Attribute, error) {
+func (s *Set) makeElemList(vals []SetElement, id uint32) ([]netlink.Attribute, error) {
 	var elements []netlink.Attribute
 
 	for i, v := range vals {
@@ -248,7 +248,7 @@ func (s *Set) makeElemList(vals []SetElement) ([]netlink.Attribute, error) {
 
 	return []netlink.Attribute{
 		{Type: unix.NFTA_SET_NAME, Data: []byte(s.Name + "\x00")},
-		{Type: unix.NFTA_SET_KEY_TYPE, Data: binaryutil.BigEndian.PutUint32(unix.NFTA_DATA_VALUE)},
+		{Type: unix.NFTA_LOOKUP_SET_ID, Data: binaryutil.BigEndian.PutUint32(id)},
 		{Type: unix.NFTA_SET_TABLE, Data: []byte(s.Table.Name + "\x00")},
 		{Type: unix.NFTA_SET_ELEM_LIST_ELEMENTS | unix.NLA_F_NESTED, Data: encodedElem},
 	}, nil
@@ -338,7 +338,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	// Set the values of the set if initial values were provided.
 	if len(vals) > 0 {
 		hdrType := unix.NFT_MSG_NEWSETELEM
-		elements, err := s.makeElemList(vals)
+		elements, err := s.makeElemList(vals, s.ID)
 		if err != nil {
 			return err
 		}
@@ -379,7 +379,7 @@ func (cc *Conn) SetDeleteElements(s *Set, vals []SetElement) error {
 		return errors.New("anonymous sets cannot be updated")
 	}
 
-	elements, err := s.makeElemList(vals)
+	elements, err := s.makeElemList(vals, s.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fix the Obj API:

Currently:
- GetObj(Obj) : return all counters, not only the given one 
- GetObjReset(Obj) : reset all counters, not only the given one

The consequence of that:
- No clean API to retrieve all counters
- No API to retrieve values of a given counter
- No API to reset a given counter

This PR add the following methods:
GetObj(o

-  Obj) (Obj, error)
- GetObjs(t Table) ([]Obj, error)
- ResetObj(o Obj) (Obj, error)
- ResetObjs(t Table) ([]Obj, error)

Related to https://github.com/google/nftables/issues/90