### PR TITLE
disable lock when no namespace is needed

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -88,7 +88,14 @@ func (cc *Conn) dialNetlink() (*netlink.Conn, error) {
 	if cc.TestDial != nil {
 		return nltest.Dial(cc.TestDial), nil
 	}
-	return netlink.Dial(unix.NETLINK_NETFILTER, &netlink.Config{NetNS: cc.NetNS})
+
+	disableNSLockThread := false
+	if cc.NetNS == 0 {
+		// Since process is operating in main namespace, there is no reason to have NSLockThread lock,
+		// as it causes some performance penalties.
+		disableNSLockThread = true
+	}
+	return netlink.Dial(unix.NETLINK_NETFILTER, &netlink.Config{NetNS: cc.NetNS, DisableNSLockThread: disableNSLockThread})
 }
 
 func (cc *Conn) setErr(err error) {


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently nftables when it calls netlink.Dial it does not  regard if only main network namespace (0) or a child network namespace (!=0) is passed to netlink.Config struct. As a result DisableNSLockThread is triggered for both cases. DisableNSLockThread causes some performance degradation and it is not really needed for main network namespace.
This PR disables this lock when only  main network namespace (0) is used, but preserving it for safety for child network namespace cases. Tests showed on average 2x - 3x performance improvement.