### PR TITLE
Add Dynset expression and unit test

### DIFF
--- a/expr/dynset.go
+++ b/expr/dynset.go
@@ -38,7 +38,9 @@ func (e *Dynset) marshal() ([]byte, error) {
 	// See: https://git.netfilter.org/libnftnl/tree/src/expr/dynset.c
 	var opAttrs []netlink.Attribute
 	opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_SREG_KEY, Data: binaryutil.BigEndian.PutUint32(e.SrcRegKey)})
-	opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_SREG_DATA, Data: binaryutil.BigEndian.PutUint32(e.SrcRegData)})
+	if e.SrcRegData != 0 {
+		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_SREG_DATA, Data: binaryutil.BigEndian.PutUint32(e.SrcRegData)})
+	}
 	opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_OP, Data: binaryutil.BigEndian.PutUint32(e.Operation)})
 	if e.Timeout != 0 {
 		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_TIMEOUT, Data: binaryutil.BigEndian.PutUint64(uint64(e.Timeout.Milliseconds()))})
@@ -76,6 +78,8 @@ func (e *Dynset) unmarshal(data []byte) error {
 			e.SrcRegKey = ad.Uint32()
 		case unix.NFTA_DYNSET_SREG_DATA:
 			e.SrcRegData = ad.Uint32()
+		case unix.NFTA_DYNSET_OP:
+			e.Operation = ad.Uint32()
 		case unix.NFTA_DYNSET_TIMEOUT:
 			e.Timeout = time.Duration(ad.Uint64() * 1000)
 		case unix.NFTA_DYNSET_FLAGS:

--- a/expr/dynset.go
+++ b/expr/dynset.go
@@ -81,7 +81,7 @@ func (e *Dynset) unmarshal(data []byte) error {
 		case unix.NFTA_DYNSET_OP:
 			e.Operation = ad.Uint32()
 		case unix.NFTA_DYNSET_TIMEOUT:
-			e.Timeout = time.Duration(ad.Uint64() * 1000)
+			e.Timeout = time.Duration(time.Millisecond * time.Duration(ad.Uint64()))
 		case unix.NFTA_DYNSET_FLAGS:
 			e.Invert = (ad.Uint32() & unix.NFT_DYNSET_F_INV) != 0
 		}

--- a/expr/dynset.go
+++ b/expr/dynset.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expr
+
+import (
+	"encoding/binary"
+
+	"github.com/google/nftables/binaryutil"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// Dynset represent a rule dynamically adding or updating a set or a map based on an incoming packet.
+type Dynset struct {
+	SrcRegKey  uint32
+	SrcRegData uint32
+	SetID      uint32
+	SetName    string
+	Operation  uint32
+	Timeout    uint64
+	Invert     bool
+}
+
+func (e *Dynset) marshal() ([]byte, error) {
+	// See: https://git.netfilter.org/libnftnl/tree/src/expr/dynset.c
+	var opAttrs []netlink.Attribute
+	opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_SREG_KEY, Data: binaryutil.BigEndian.PutUint32(e.SrcRegKey)})
+	opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_SREG_DATA, Data: binaryutil.BigEndian.PutUint32(e.SrcRegData)})
+	opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_OP, Data: binaryutil.BigEndian.PutUint32(e.Operation)})
+	if e.Timeout != 0 {
+		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_TIMEOUT, Data: binaryutil.BigEndian.PutUint64(e.Timeout)})
+	}
+	if e.Invert {
+		opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_FLAGS, Data: binaryutil.BigEndian.PutUint32(unix.NFT_DYNSET_F_INV)})
+	}
+	opAttrs = append(opAttrs,
+		netlink.Attribute{Type: unix.NFTA_DYNSET_SET_NAME, Data: []byte(e.SetName + "\x00")},
+		netlink.Attribute{Type: unix.NFTA_DYNSET_SET_ID, Data: binaryutil.BigEndian.PutUint32(e.SetID)})
+	opData, err := netlink.MarshalAttributes(opAttrs)
+	if err != nil {
+		return nil, err
+	}
+
+	return netlink.MarshalAttributes([]netlink.Attribute{
+		{Type: unix.NFTA_EXPR_NAME, Data: []byte("dynset\x00")},
+		{Type: unix.NLA_F_NESTED | unix.NFTA_EXPR_DATA, Data: opData},
+	})
+}
+
+func (e *Dynset) unmarshal(data []byte) error {
+	ad, err := netlink.NewAttributeDecoder(data)
+	if err != nil {
+		return err
+	}
+	ad.ByteOrder = binary.BigEndian
+	for ad.Next() {
+		switch ad.Type() {
+		case unix.NFTA_DYNSET_SET_NAME:
+			e.SetName = ad.String()
+		case unix.NFTA_DYNSET_SET_ID:
+			e.SetID = ad.Uint32()
+		case unix.NFTA_DYNSET_SREG_KEY:
+			e.SrcRegKey = ad.Uint32()
+		case unix.NFTA_DYNSET_SREG_DATA:
+			e.SrcRegData = ad.Uint32()
+		case unix.NFTA_DYNSET_TIMEOUT:
+			e.Timeout = ad.Uint64()
+		case unix.NFTA_DYNSET_FLAGS:
+			e.Invert = (ad.Uint32() & unix.NFT_DYNSET_F_INV) != 0
+		}
+	}
+	return ad.Err()
+}

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -2530,19 +2530,14 @@ func TestDynset(t *testing.T) {
 			&expr.Payload{
 				DestRegister: 1,
 				Base:         expr.PayloadBaseNetworkHeader,
-				Offset:       12,
-				Len:          4,
-			},
-			&expr.Immediate{
-				Register: 2,
-				Data:     []byte{0x0, 0x0, 0x0, 0x2},
+				Offset:       uint32(12),
+				Len:          uint32(4),
 			},
 			&expr.Dynset{
-				SrcRegKey:  1,
-				SrcRegData: 2,
-				SetName:    set.Name,
-				SetID:      set.ID,
-				Operation:  uint32(unix.NFT_DYNSET_OP_UPDATE),
+				SrcRegKey: 1,
+				SetName:   set.Name,
+				SetID:     set.ID,
+				Operation: uint32(unix.NFT_DYNSET_OP_UPDATE),
 			},
 		},
 	})
@@ -2567,20 +2562,18 @@ func TestDynset(t *testing.T) {
 	if got, want := len(rules), 1; got != want {
 		t.Fatalf("unexpected number of rules: got %d, want %d", got, want)
 	}
-	if got, want := len(rules[0].Exprs), 3; got != want {
+	if got, want := len(rules[0].Exprs), 2; got != want {
 		t.Fatalf("unexpected number of exprs: got %d, want %d", got, want)
 	}
 
-	dynset, dynsetOk := rules[0].Exprs[2].(*expr.Dynset)
+	dynset, dynsetOk := rules[0].Exprs[1].(*expr.Dynset)
 	if !dynsetOk {
-		t.Fatalf("Exprs[3] is type %T, want *expr.Dynset", rules[0].Exprs[2])
+		t.Fatalf("Exprs[0] is type %T, want *expr.Dynset", rules[0].Exprs[1])
 	}
 	if want := (&expr.Dynset{
-		SrcRegKey:  1,
-		SrcRegData: 2,
-		SetName:    set.Name,
-		SetID:      set.ID,
-		Operation:  uint32(unix.NFT_DYNSET_OP_UPDATE),
+		SrcRegKey: 1,
+		SetName:   set.Name,
+		Operation: uint32(unix.NFT_DYNSET_OP_UPDATE),
 	}); !reflect.DeepEqual(dynset, want) {
 		t.Errorf("dynset expr = %+v, wanted %+v", dynset, want)
 	}

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/binaryutil"
@@ -2513,7 +2514,7 @@ func TestDynset(t *testing.T) {
 		Name:       "dynamic-set",
 		KeyType:    nftables.TypeIPAddr,
 		HasTimeout: true,
-		Timeout:    600 * 1000, // Timeout is specified in milliseconds
+		Timeout:    time.Duration(600 * time.Second),
 	}
 	if err := c.AddSet(set, nil); err != nil {
 		t.Errorf("c.AddSet(portSet) failed: %v", err)

--- a/rule.go
+++ b/rule.go
@@ -240,6 +240,8 @@ func exprsFromMsg(b []byte) ([]expr.Any, error) {
 						e = &expr.Redir{}
 					case "nat":
 						e = &expr.NAT{}
+					case "dynset":
+						e = &expr.Dynset{}
 					}
 					if e == nil {
 						// TODO: introduce an opaque expression type so that users know

--- a/set.go
+++ b/set.go
@@ -173,7 +173,7 @@ func (s *SetElement) decode() func(b []byte) error {
 				flags := ad.Uint32()
 				s.IntervalEnd = (flags & unix.NFT_SET_ELEM_INTERVAL_END) != 0
 			case unix.NFTA_SET_ELEM_TIMEOUT:
-				s.Timeout = time.Duration(ad.Uint64() * 1000)
+				s.Timeout = time.Duration(time.Millisecond * time.Duration(ad.Uint64()))
 			}
 		}
 		return ad.Err()
@@ -490,7 +490,7 @@ func setsFromMsg(msg netlink.Message) (*Set, error) {
 		case unix.NFTA_SET_ID:
 			set.ID = binary.BigEndian.Uint32(ad.Bytes())
 		case unix.NFTA_SET_TIMEOUT:
-			set.Timeout = time.Duration(binary.BigEndian.Uint64(ad.Bytes()) * 1000)
+			set.Timeout = time.Duration(time.Millisecond * time.Duration(binary.BigEndian.Uint64(ad.Bytes())))
 			set.HasTimeout = true
 		case unix.NFTA_SET_FLAGS:
 			flags := ad.Uint32()


### PR DESCRIPTION
In order to be able to build dynamic sets or maps; sets where entries are aging out with time but are refreshed by the actual incoming traffic, `dynset` expression is required.

It allows to build this type of rules:
```
table ip kube-nfproxy-v4 {
	map sticky-set-svc-M53CN2XYVUHRQ7UB {
		type ipv4_addr : integer
		size 65535
		timeout 6m
		elements = { 192.168.10.10 timeout 10s expires 5s384ms : 2 }
	}

	chain k8s-nfproxy-sep-TMVEFT7EX55F4T62 {
		update @sticky-set-svc-M53CN2XYVUHRQ7UB { ip saddr : 0x2  }
	}
```

Entry 192.168.10.10 in map sticky-set-svc-M53CN2XYVUHRQ7UB will age out in 5 seconds unless there will be a packet which will hit chain `k8s-nfproxy-sep-TMVEFT7EX55F4T62`  and  reset age back to 10 seconds.

@stapelberg  Please check this out when you have a second, it should be merged after Adding Timeout to Set PR.