### PR TITLE
Report whether set has timeout flag configured

### DIFF
--- a/set.go
+++ b/set.go
@@ -498,6 +498,7 @@ func setsFromMsg(msg netlink.Message) (*Set, error) {
 			set.Anonymous = (flags & unix.NFT_SET_ANONYMOUS) != 0
 			set.Interval = (flags & unix.NFT_SET_INTERVAL) != 0
 			set.IsMap = (flags & unix.NFTA_SET_TABLE) != 0
+			set.HasTimeout = (flags & unix.NFTA_SET_TIMEOUT) != 0
 		case unix.NFTA_SET_KEY_TYPE:
 			nftMagic := ad.Uint32()
 			if invalidMagic, ok := validateKeyType(nftMagic); !ok {


### PR DESCRIPTION
Per-element timeouts should be configurable for a set even if a top-level set timeout isn't configured.

Example:
```
> nft list map ip nat porttoip
table ip nat {
        map porttoip {
                type inet_service : ipv4_addr
                flags timeout
                elements = { 8000 timeout 1m expires 49s32ms : 100.0.0.0 }
        }
}
```