### PR TITLE
nftables: fix staticcheck error for Conn.getObj

### DIFF
--- a/obj.go
+++ b/obj.go
@@ -185,14 +185,14 @@ func (cc *Conn) getObj(o Obj, t *Table, msgType uint16) ([]Obj, error) {
 
 	if o != nil {
 		data, err = o.marshal(false)
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		flags = netlink.Dump
 		data, err = netlink.MarshalAttributes([]netlink.Attribute{
 			{Type: unix.NFTA_RULE_TABLE, Data: []byte(t.Name + "\x00")},
 		})
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	message := netlink.Message{


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

The error was not checked in the else case, so move the error check below the conditional.