### PR TITLE
Support for rule position 0

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -42,6 +42,11 @@ type Rule struct {
 	Chain    *Chain
 	Position uint64
 	Handle   uint64
+	// The list of possible flags are specified by nftnl_rule_attr, see
+	// https://git.netfilter.org/libnftnl/tree/include/libnftnl/rule.h#n21
+	// Current nftables go implementation supports only
+	// NFTNL_RULE_POSITION flag for setting rule at position 0
+	Flags    uint32
 	Exprs    []expr.Any
 	UserData []byte
 }
@@ -136,7 +141,7 @@ func (cc *Conn) newRule(r *Rule, op ruleOperation) *Rule {
 		flags = netlink.Request | netlink.Acknowledge | netlink.Replace | unix.NLM_F_ECHO | unix.NLM_F_REPLACE
 	}
 
-	if r.Position != 0 {
+	if r.Position != 0 || (r.Flags&(1<<unix.NFTA_RULE_POSITION)) != 0 {
 		msgData = append(msgData, cc.marshalAttr([]netlink.Attribute{
 			{Type: unix.NFTA_RULE_POSITION, Data: binaryutil.BigEndian.PutUint64(r.Position)},
 		})...)


### PR DESCRIPTION
Hi all,

I have added a change that resolves the issue #126.

I checked the original netfilter and libnftnl source code and found that the `nftnl_rule` struct [contains a `uint32_t flags`](https://git.netfilter.org/libnftnl/tree/include/rule.h#n7) which is checked [during payload build](https://git.netfilter.org/libnftnl/tree/src/rule.c#n294). Some of the [`nftnl_rule_attr` flags](https://git.netfilter.org/libnftnl/tree/include/libnftnl/rule.h#n21) can be found in the [go unix package](https://cs.opensource.google/go/x/sys/+/da31bd32:unix/ztypes_linux.go;l=1894) with correct values. Therefore, my approach was to add a `Flags uint32` to the `Rule` struct and check for the `unix.NFTA_RULE_POSITION` bit. The `r.Position != 0` check remains because otherwise the change would not be backwards compatible.

Let me know what you think.
