### PR TITLE
Fix for ListChains policy bug

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -229,7 +229,7 @@ func chainFromMsg(msg netlink.Message) (*Chain, error) {
 		case unix.NFTA_CHAIN_TYPE:
 			c.Type = ChainType(ad.String())
 		case unix.NFTA_CHAIN_POLICY:
-			policy := ChainPolicy(ad.Uint32())
+			policy := ChainPolicy(binaryutil.BigEndian.Uint32(ad.Bytes()))
 			c.Policy = &policy
 		case unix.NFTA_CHAIN_HOOK:
 			ad.Do(func(b []byte) error {


### PR DESCRIPTION
Hi,

I have implemented a fix for issue #130 and added a test for it.

The original libnftnl code stores the policy value as big endian. Although this is seen [at payload build](https://git.netfilter.org/libnftnl/tree/src/chain.c#n516), the policy setting is also performed during [chain add](https://git.netfilter.org/nftables/tree/src/mnl.c#n807). I have tested the return value [coming from the AttributeDecoder](https://github.com/google/nftables/blob/a46119e5928d17563cee3bf3a5fba8dc9f79ab41/chain.go#L232) and `ad.Bytes()` always returns 4 bytes where the least significant byte holds the policy value (`0x01` for `ChainPolicyAccept` and `0x00` for `ChainPolicyDrop`):
```
$ sed -n 231,232p chain.go 
		case unix.NFTA_CHAIN_POLICY:
			fmt.Printf("policy value for chain %s: %v\n", c.Name, ad.Bytes())
$
$ cat main.go && go build main.go
package main

import (
	"fmt"
	"github.com/google/nftables"
)

func main() {
	chains, _ := (&nftables.Conn{}).ListChains()
	for _, c := range chains {
		if c.Policy != nil {
			fmt.Printf("%s: %d\n", c.Name, *c.Policy)
		}
	}
}
$
$ sudo nft list ruleset && sudo ./main
table inet filter {
	chain input {
		type filter hook input priority filter; policy accept;
	}

	chain forward {
		type filter hook forward priority filter; policy drop;
	}

	chain output {
		type filter hook output priority filter; policy accept;
	}

	chain undef {
		counter packets 56235 bytes 175436495 return
	}
}
policy value for chain input: [0 0 0 1]
policy value for chain forward: [0 0 0 0]
policy value for chain output: [0 0 0 1]
input: 16777216
forward: 0
output: 16777216
```

Since netlink lib returns the value of the 4 bytes as big endian, the only thing that makes sense here is to use the `binaryutil.BigEndian` to convert the policy value bytes to integer. I think that the bug happens because netlink lib [takes host endianness into account](https://github.com/mdlayher/netlink/blob/main/attribute.go#L330) and `Uint32()` call returns a number for `\x01\x00\x00\x00`. 

Additionally, I have added a test case for this issue which was failing before I made the change.
```
$ sed -n 231,232p chain.go 
		case unix.NFTA_CHAIN_POLICY:
			policy := ChainPolicy(ad.Uint32())
$ go test -run "TestListChains"
--- FAIL: TestListChains (0.00s)
    nftables_test.go:1245: chain 0: chain policy value mismatch, got 16777216 want 1
    nftables_test.go:1245: chain 2: chain policy value mismatch, got 16777216 want 1
FAIL
exit status 1
FAIL	github.com/google/nftables	0.002s
$
$ sed -n 231,232p chain.go 
		case unix.NFTA_CHAIN_POLICY:
			policy := ChainPolicy(binaryutil.BigEndian.Uint32(ad.Bytes()))
$ go test -run "TestListChains"
PASS
ok  	github.com/google/nftables	0.002s
```

Let me know what you think.