### PR TITLE
Log prefix expression support

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -253,6 +253,8 @@ func exprsFromMsg(b []byte) ([]expr.Any, error) {
 						e = &expr.Limit{}
 					case "dynset":
 						e = &expr.Dynset{}
+					case "log":
+						e = &expr.Log{}
 					}
 					if e == nil {
 						// TODO: introduce an opaque expression type so that users know


### PR DESCRIPTION
Hi,

I have added the `expr.Log` case to the `name` switch of the `unix.NFTA_DATA_EXPR` case as proposed in https://github.com/google/nftables/issues/115 which adds the support for log prefix parsing. I have also enriched your existing `GetRule` test to check the log prefix expression support and whether the addition works correctly.

Let me know what you think.