### PR TITLE
Log expression refactor to better support multiple log options

### DIFF
--- a/binaryutil/binaryutil.go
+++ b/binaryutil/binaryutil.go
@@ -26,6 +26,7 @@ type ByteOrder interface {
 	PutUint16(v uint16) []byte
 	PutUint32(v uint32) []byte
 	PutUint64(v uint64) []byte
+	Uint16(b []byte) uint16
 	Uint32(b []byte) uint32
 	Uint64(b []byte) uint64
 }
@@ -52,6 +53,10 @@ func (nativeEndian) PutUint64(v uint64) []byte {
 	buf := make([]byte, 8)
 	*(*uint64)(unsafe.Pointer(&buf[0])) = v
 	return buf
+}
+
+func (nativeEndian) Uint16(b []byte) uint16 {
+	return *(*uint16)(unsafe.Pointer(&b[0]))
 }
 
 func (nativeEndian) Uint32(b []byte) uint32 {
@@ -84,6 +89,10 @@ func (bigEndian) PutUint64(v uint64) []byte {
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, v)
 	return buf
+}
+
+func (bigEndian) Uint16(b []byte) uint16 {
+	return binary.BigEndian.Uint16(b)
 }
 
 func (bigEndian) Uint32(b []byte) uint32 {


### PR DESCRIPTION
Hi,

I am proposing a major change to the log expression support. Current implementation does not support all log options and performs incorrect or incomplete marshaling of log expressions. Let me demonstrate current state of the log expression with two simple code snippets.

Here is how the nftables lib marshals multiple log expressions (observe multiple "log" attributes at the end):
```
$ sed -n '9,$p' main.go
func main() {
	c := &nftables.Conn{}
	filter := c.AddTable(&nftables.Table{
		Family: nftables.TableFamilyIPv4,
		Name:   "filter",
	})
	input := c.AddChain(&nftables.Chain{
		Name:     "input",
		Table:    filter,
		Type:     nftables.ChainTypeFilter,
		Hooknum:  nftables.ChainHookInput,
		Priority: nftables.ChainPriorityFilter,
	})

	c.AddRule(&nftables.Rule{
		Table: filter,
		Chain: input,
		Exprs: []expr.Any{
			&expr.Log{
				Key:  unix.NFTA_LOG_PREFIX,
				Data: []byte("LOG INPUT"),
			},
			&expr.Log{
				Key:  unix.NFTA_LOG_GROUP,
				Data: []byte{0x00, 0x00},
			},
			&expr.Log{
				Key:  unix.NFTA_LOG_QTHRESHOLD,
				Data: []byte{0x00, 0x20},
			},
		},
	})

	if err := c.Flush(); err != nil {
		panic(err)
	}
}
$ nft flush ruleset && go build main.go && ./main
$ nft list ruleset
table ip filter {
	chain input {
		type filter hook input priority filter; policy accept;
		log prefix "LOG INPUT" log group 0 log
	}
}
```

And here is how the nftables lib unmarshals the existing log expressions (note that log group and log qthreshold are never read):
```
$ sed -n '8,$p' main.go
func main() {
	c := &nftables.Conn{}
	rules, err := c.GetRule(
		&nftables.Table{
			Family: nftables.TableFamilyIPv4,
			Name:   "filter",
		},
		&nftables.Chain{
			Name: "input",
		},
	)
	if err != nil {
		panic(err)
	}
	fmt.Printf("number of rules in input: %d\n", len(rules))
	fmt.Printf("number of expressions in input: %d\n", len(rules[0].Exprs))
	fmt.Printf("expression content: %#v\n", rules[0].Exprs[0])
}
$ nft list ruleset
table ip filter {
	chain input {
		type filter hook input priority filter; policy accept;
		log prefix "input accept" group 0 queue-threshold 20
	}

	chain forward {
		type filter hook forward priority filter; policy drop;
	}

	chain output {
		type filter hook output priority filter; policy accept;
	}
}
$ go build main.go && ./main
number of rules in input: 1
number of expressions in input: 1
expression content: &expr.Log{Key:0x2, Data:[]uint8{0x69, 0x6e, 0x70, 0x75, 0x74, 0x20, 0x61, 0x63, 0x63, 0x65, 0x70, 0x74}}
```

I have refactored the log expression logic in order to improve content marshaling and also:
- added the uint16 support to the binaryutil
- changed old log tests that were failing after the change
- added a new test to check the implementation for multiple options

Here is how nftables log marshaling works after change:
```
$ sed -n '9,$p' main.go
func main() {
	c := &nftables.Conn{}
	filter := c.AddTable(&nftables.Table{
		Family: nftables.TableFamilyIPv4,
		Name:   "filter",
	})
	input := c.AddChain(&nftables.Chain{
		Name:     "input",
		Table:    filter,
		Type:     nftables.ChainTypeFilter,
		Hooknum:  nftables.ChainHookInput,
		Priority: nftables.ChainPriorityFilter,
	})

	c.AddRule(&nftables.Rule{
		Table: filter,
		Chain: input,
		Exprs: []expr.Any{
			&expr.Log{
				Key:        (1 << unix.NFTA_LOG_PREFIX) | (1 << unix.NFTA_LOG_GROUP) | (1 << unix.NFTA_LOG_QTHRESHOLD),
				Data:       []byte("LOG INPUT"),
				Group:      0,
				QThreshold: 20,
			},
		},
	})

	if err := c.Flush(); err != nil {
		panic(err)
	}
}
$ nft flush ruleset && go build main.go && ./main
$ nft list ruleset
table ip filter {
	chain input {
		type filter hook input priority filter; policy accept;
		log prefix "LOG INPUT" group 0 queue-threshold 20
	}
}
$ vim main.go
$ sed -n '8,$p' main.go
func main() {
	c := &nftables.Conn{}
	rules, err := c.GetRule(
		&nftables.Table{
			Family: nftables.TableFamilyIPv4,
			Name:   "filter",
		},
		&nftables.Chain{
			Name: "input",
		},
	)
	if err != nil {
		panic(err)
	}
	fmt.Printf("number of rules in input: %d\n", len(rules))
	fmt.Printf("number of expressions in input: %d\n", len(rules[0].Exprs))
	fmt.Printf("expression content: %#v\n", rules[0].Exprs[0])
}
$ nft -f /etc/nftables.conf
$ nft list ruleset
table ip filter {
	chain input {
		type filter hook input priority filter; policy accept;
		log prefix "input accept" group 0 queue-threshold 20
	}

	chain forward {
		type filter hook forward priority filter; policy drop;
	}

	chain output {
		type filter hook output priority filter; policy accept;
	}
}
$ go build main.go && ./main
number of rules in input: 1
number of expressions in input: 1
expression content: &expr.Log{Level:0x0, Flags:0x0, Key:0x16, Snaplen:0x0, Group:0x0, QThreshold:0x14, Data:[]uint8{0x69, 0x6e, 0x70, 0x75, 0x74, 0x20, 0x61, 0x63, 0x63, 0x65, 0x70, 0x74}}
```

Let me know what you think.