### PR TITLE
Fix expression parsing data

### DIFF
--- a/expr/payload.go
+++ b/expr/payload.go
@@ -112,6 +112,7 @@ func (e *Payload) unmarshal(data []byte) error {
 			e.DestRegister = ad.Uint32()
 		case unix.NFTA_PAYLOAD_SREG:
 			e.SourceRegister = ad.Uint32()
+			e.OperationType = PayloadWrite
 		case unix.NFTA_PAYLOAD_BASE:
 			e.Base = PayloadBase(ad.Uint32())
 		case unix.NFTA_PAYLOAD_OFFSET:

--- a/expr/range.go
+++ b/expr/range.go
@@ -77,9 +77,35 @@ func (e *Range) unmarshal(data []byte) error {
 		case unix.NFTA_RANGE_SREG:
 			e.Register = ad.Uint32()
 		case unix.NFTA_RANGE_FROM_DATA:
-			e.FromData = ad.Bytes()
+			ad.Do(func(b []byte) error {
+				ad, err := netlink.NewAttributeDecoder(b)
+				if err != nil {
+					return err
+				}
+				ad.ByteOrder = binary.BigEndian
+				if ad.Next() && ad.Type() == unix.NFTA_DATA_VALUE {
+					ad.Do(func(b []byte) error {
+						e.FromData = b
+						return nil
+					})
+				}
+				return ad.Err()
+			})
 		case unix.NFTA_RANGE_TO_DATA:
-			e.ToData = ad.Bytes()
+			ad.Do(func(b []byte) error {
+				ad, err := netlink.NewAttributeDecoder(b)
+				if err != nil {
+					return err
+				}
+				ad.ByteOrder = binary.BigEndian
+				if ad.Next() && ad.Type() == unix.NFTA_DATA_VALUE {
+					ad.Do(func(b []byte) error {
+						e.ToData = b
+						return nil
+					})
+				}
+				return ad.Err()
+			})
 		}
 	}
 	return ad.Err()

--- a/rule.go
+++ b/rule.go
@@ -227,6 +227,10 @@ func exprsFromMsg(b []byte) ([]expr.Any, error) {
 				switch ad.Type() {
 				case unix.NFTA_EXPR_NAME:
 					name = ad.String()
+					if name == "notrack" {
+						e := &expr.Notrack{}
+						exprs = append(exprs, e)
+					}
 				case unix.NFTA_EXPR_DATA:
 					var e expr.Any
 					switch name {


### PR DESCRIPTION
Have found different errors on unmarshalling the data expressions for `Range`, `Payload` and `Notrack`:
 * Fix `Range` fields `ToData` and `FromData` unmarshalling.
 * Update the `Payload` field `OperationType` when receiving a `SREG` (follows the same principle that is done while Marshalling)
 * Fix the `Notrack` expression, that has no data associated.