### PR TITLE
implement "lasting" connections, issue #157

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -32,18 +32,138 @@ import (
 // Commands are buffered. Flush sends all buffered commands in a single batch.
 type Conn struct {
 	TestDial nltest.Func // for testing only; passed to nltest.Dial
-	NetNS    int         // Network namespace netlink will interact with.
-	sync.Mutex
+	NetNS    int         // fd referencing the network namespace netlink will interact with.
+
+	lasting  bool       // establish a lasting connection to be used across multiple netlink operations.
+	mu       sync.Mutex // protects the following state
 	messages []netlink.Message
 	err      error
+	nlconn   *netlink.Conn // netlink socket using NETLINK_NETFILTER protocol.
+}
+
+// ConnOption is an option to change the behavior of the nftables Conn returned by Open.
+type ConnOption func(*Conn)
+
+// New returns a netlink connection for querying and modifying nftables. Some
+// aspects of the new netlink connection can be configured using the options
+// WithNetNSFd, WithTestDial, and AsLasting.
+//
+// A lasting netlink connection should be closed by calling CloseLasting() to
+// close the underlying lasting netlink connection, cancelling all pending
+// operations using this connection.
+func New(opts ...ConnOption) (*Conn, error) {
+	cc := &Conn{}
+	for _, opt := range opts {
+		opt(cc)
+	}
+
+	if !cc.lasting {
+		return cc, nil
+	}
+
+	nlconn, err := cc.dialNetlink()
+	if err != nil {
+		return nil, err
+	}
+	cc.nlconn = nlconn
+	return cc, nil
+}
+
+// AsLasting creates the new netlink connection as a lasting connection that is
+// reused across multiple netlink operations, instead of opening and closing the
+// underlying netlink connection only for the duration of a single netlink
+// operation.
+func AsLasting() ConnOption {
+	return func(cc *Conn) {
+		// We cannot create the underlying connection yet, as we are called
+		// anywhere in the option processing chain and there might be later
+		// options still modifying connection behavior.
+		cc.lasting = true
+	}
+}
+
+// WithNetNSFd sets the network namespace to create a new netlink connection to:
+// the fd must reference a network namespace.
+func WithNetNSFd(fd int) ConnOption {
+	return func(cc *Conn) {
+		cc.NetNS = fd
+	}
+}
+
+// WithTestDial sets the specified nltest.Func when creating a new netlink
+// connection.
+func WithTestDial(f nltest.Func) ConnOption {
+	return func(cc *Conn) {
+		cc.TestDial = f
+	}
+}
+
+// netlinkCloser is returned by netlinkConn(UnderLock) and must be called after
+// being done with the returned netlink connection in order to properly close
+// this connection, if necessary.
+type netlinkCloser func() error
+
+// netlinkConn returns a netlink connection together with a netlinkCloser that
+// later must be called by the caller when it doesn't need the returned netlink
+// connection anymore. The netlinkCloser will close the netlink connection when
+// necessary. If New has been told to create a lasting connection, then this
+// lasting netlink connection will be returned, otherwise a new "transient"
+// netlink connection will be opened and returned instead. netlinkConn must not
+// be called while the Conn.mu lock is currently helt (this will cause a
+// deadlock). Use netlinkConnUnderLock instead in such situations.
+func (cc *Conn) netlinkConn() (*netlink.Conn, netlinkCloser, error) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	return cc.netlinkConnUnderLock()
+}
+
+// netlinkConnUnderLock works like netlinkConn but must be called while holding
+// the Conn.mu lock.
+func (cc *Conn) netlinkConnUnderLock() (*netlink.Conn, netlinkCloser, error) {
+	if cc.nlconn != nil {
+		return cc.nlconn, func() error { return nil }, nil
+	}
+	nlconn, err := cc.dialNetlink()
+	if err != nil {
+		return nil, nil, err
+	}
+	return nlconn, func() error { return nlconn.Close() }, nil
+}
+
+// CloseLasting closes the lasting netlink connection that has been opened using
+// AsLasting option when creating this connection. If either no lasting netlink
+// connection has been opened or the lasting connection is already in the
+// process of closing or has been closed, CloseLasting will immediately return
+// without any error.
+//
+// CloseLasting will terminate all pending netlink operations using the lasting
+// connection.
+//
+// After closing a lasting connection, the connection will revert to using
+// on-demand transient netlink connections when calling further netlink
+// operations (such as GetTables).
+func (cc *Conn) CloseLasting() error {
+	// Don't acquire the lock for the whole duration of the CloseLasting
+	// operation, but instead only so long as to make sure to only run the
+	// netlink socket close on the first time with a lasting netlink socket. As
+	// there is only the New() constructor, but no Open() method, it's
+	// impossible to reopen a lasting connection.
+	cc.mu.Lock()
+	nlconn := cc.nlconn
+	cc.nlconn = nil
+	cc.mu.Unlock()
+	if nlconn != nil {
+		return nlconn.Close()
+	}
+	return nil
 }
 
 // Flush sends all buffered commands in a single batch to nftables.
 func (cc *Conn) Flush() error {
-	cc.Lock()
+	cc.mu.Lock()
 	defer func() {
 		cc.messages = nil
-		cc.Unlock()
+		cc.mu.Unlock()
 	}()
 	if len(cc.messages) == 0 {
 		// Messages were already programmed, returning nil
@@ -52,12 +172,11 @@ func (cc *Conn) Flush() error {
 	if cc.err != nil {
 		return cc.err // serialization error
 	}
-	conn, err := cc.dialNetlink()
+	conn, closer, err := cc.netlinkConnUnderLock()
 	if err != nil {
 		return err
 	}
-
-	defer conn.Close()
+	defer func() { _ = closer() }()
 
 	if _, err := conn.SendMessages(batch(cc.messages)); err != nil {
 		return fmt.Errorf("SendMessages: %w", err)
@@ -73,8 +192,8 @@ func (cc *Conn) Flush() error {
 // FlushRuleset flushes the entire ruleset. See also
 // https://wiki.nftables.org/wiki-nftables/index.php/Operations_at_ruleset_level
 func (cc *Conn) FlushRuleset() {
-	cc.Lock()
-	defer cc.Unlock()
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
 	cc.messages = append(cc.messages, netlink.Message{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELTABLE),


### PR DESCRIPTION
- add New constructor, Close receiver to optionally support "lasting" netlink connections while defaulting to existing temporary netlink connection usage
- add unit test for New, Close and correct default connection handling behavior
- make Conn mutex un-exported
- refactor tests to use New constructor
- ~~rename GetRule to GetRules and deprecate GetRule, update usage~~ broken out into separate PR #160