### PR TITLE
Added dynset expressions support

### DIFF
--- a/expr/connlimit.go
+++ b/expr/connlimit.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expr
+
+import (
+	"encoding/binary"
+
+	"github.com/google/nftables/binaryutil"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// Per https://git.netfilter.org/libnftnl/tree/include/linux/netfilter/nf_tables.h?id=84d12cfacf8ddd857a09435f3d982ab6250d250c#n1167
+	NFTA_CONNLIMIT_UNSPEC = iota
+	NFTA_CONNLIMIT_COUNT
+	NFTA_CONNLIMIT_FLAGS
+	NFT_CONNLIMIT_F_INV = 1
+)
+
+// Per https://git.netfilter.org/libnftnl/tree/src/expr/connlimit.c?id=84d12cfacf8ddd857a09435f3d982ab6250d250c
+type Connlimit struct {
+	Count uint32
+	Flags uint32
+}
+
+func (e *Connlimit) marshal(fam byte) ([]byte, error) {
+	data, err := netlink.MarshalAttributes([]netlink.Attribute{
+		{Type: NFTA_CONNLIMIT_COUNT, Data: binaryutil.BigEndian.PutUint32(e.Count)},
+		{Type: NFTA_CONNLIMIT_FLAGS, Data: binaryutil.BigEndian.PutUint32(e.Flags)},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return netlink.MarshalAttributes([]netlink.Attribute{
+		{Type: unix.NFTA_EXPR_NAME, Data: []byte("connlimit\x00")},
+		{Type: unix.NLA_F_NESTED | unix.NFTA_EXPR_DATA, Data: data},
+	})
+}
+
+func (e *Connlimit) unmarshal(fam byte, data []byte) error {
+	ad, err := netlink.NewAttributeDecoder(data)
+	if err != nil {
+		return err
+	}
+
+	ad.ByteOrder = binary.BigEndian
+	for ad.Next() {
+		switch ad.Type() {
+		case NFTA_CONNLIMIT_COUNT:
+			e.Count = binaryutil.BigEndian.Uint32(ad.Bytes())
+		case NFTA_CONNLIMIT_FLAGS:
+			e.Flags = binaryutil.BigEndian.Uint32(ad.Bytes())
+		}
+	}
+	return ad.Err()
+}

--- a/expr/limit.go
+++ b/expr/limit.go
@@ -72,24 +72,16 @@ type Limit struct {
 }
 
 func (l *Limit) marshal(fam byte) ([]byte, error) {
+	var flags uint32
+	if l.Over {
+		flags = unix.NFT_LIMIT_F_INV
+	}
 	attrs := []netlink.Attribute{
-		{Type: unix.NFTA_LIMIT_TYPE, Data: binaryutil.BigEndian.PutUint32(uint32(l.Type))},
 		{Type: unix.NFTA_LIMIT_RATE, Data: binaryutil.BigEndian.PutUint64(l.Rate)},
 		{Type: unix.NFTA_LIMIT_UNIT, Data: binaryutil.BigEndian.PutUint64(uint64(l.Unit))},
-	}
-
-	if l.Over {
-		attrs = append(attrs, netlink.Attribute{
-			Type: unix.NFTA_LIMIT_FLAGS,
-			Data: binaryutil.BigEndian.PutUint32(unix.NFT_LIMIT_F_INV),
-		})
-	}
-
-	if l.Burst != 0 {
-		attrs = append(attrs, netlink.Attribute{
-			Type: unix.NFTA_LIMIT_BURST,
-			Data: binaryutil.BigEndian.PutUint32(l.Burst),
-		})
+		{Type: unix.NFTA_LIMIT_BURST, Data: binaryutil.BigEndian.PutUint32(l.Burst)},
+		{Type: unix.NFTA_LIMIT_TYPE, Data: binaryutil.BigEndian.PutUint32(uint32(l.Type))},
+		{Type: unix.NFTA_LIMIT_FLAGS, Data: binaryutil.BigEndian.PutUint32(flags)},
 	}
 
 	data, err := netlink.MarshalAttributes(attrs)

--- a/internal/parseexprfunc/parseexprfunc.go
+++ b/internal/parseexprfunc/parseexprfunc.go
@@ -1,0 +1,10 @@
+package parseexprfunc
+
+import (
+	"github.com/mdlayher/netlink"
+)
+
+var (
+	ParseExprBytesFunc func(fam byte, ad *netlink.AttributeDecoder, b []byte) ([]interface{}, error)
+	ParseExprMsgFunc   func(fam byte, b []byte) ([]interface{}, error)
+)

--- a/set.go
+++ b/set.go
@@ -235,6 +235,10 @@ type Set struct {
 	Interval   bool
 	IsMap      bool
 	HasTimeout bool
+	// Can be updated per evaluation path, per `nft list ruleset`
+	// indicates that set contains "flags dynamic"
+	// https://git.netfilter.org/libnftnl/tree/include/linux/netfilter/nf_tables.h?id=84d12cfacf8ddd857a09435f3d982ab6250d250c#n298
+	Dynamic bool
 	// Indicates that the set contains a concatenation
 	// https://git.netfilter.org/nftables/tree/include/linux/netfilter/nf_tables.h?id=d1289bff58e1878c3162f574c603da993e29b113#n306
 	Concatenation bool
@@ -467,6 +471,9 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	}
 	if s.HasTimeout {
 		flags |= unix.NFT_SET_TIMEOUT
+	}
+	if s.Dynamic {
+		flags |= unix.NFT_SET_EVAL
 	}
 	if s.Concatenation {
 		flags |= NFT_SET_CONCAT

--- a/table.go
+++ b/table.go
@@ -104,7 +104,7 @@ func (cc *Conn) ListTables() ([]*Table, error) {
 	return cc.ListTablesOfFamily(TableFamilyUnspecified)
 }
 
-// ListTables returns currently configured tables for the specified table family
+// ListTablesOfFamily returns currently configured tables for the specified table family
 // in the kernel. It lists all tables if family is TableFamilyUnspecified.
 func (cc *Conn) ListTablesOfFamily(family TableFamily) ([]*Table, error) {
 	conn, closer, err := cc.netlinkConn()


### PR DESCRIPTION
Hi,

I have added support for dynset expressions as suggested in #172. The pull request contains a bit more than just adding support for dynset expressions:
- Function `exprFromMsg` is now moved to the `expr` package and made public
- Limit expression marshaling logic is changed to better correspond to nftables messages
- Added separate tests for one and multiple dynset expressions (also demonstrates how to create meters)
- Added additional dynamic flag to sets which was missing in order to fully support meters
- Added a small set of new constants which are still not supported by unix package
- Added an additional connlimit expr implementation which was not supported

Let me know what you think.