### PR TITLE
IsDestRegSet unmarshaling fix

### DIFF
--- a/expr/lookup.go
+++ b/expr/lookup.go
@@ -76,6 +76,7 @@ func (e *Lookup) unmarshal(fam byte, data []byte) error {
 			e.SourceRegister = ad.Uint32()
 		case unix.NFTA_LOOKUP_DREG:
 			e.DestRegister = ad.Uint32()
+			e.IsDestRegSet = true
 		case unix.NFTA_LOOKUP_FLAGS:
 			e.Invert = (ad.Uint32() & unix.NFT_LOOKUP_F_INV) != 0
 		}


### PR DESCRIPTION
Hi,

as noted in issue #176, the Lookup expression does not set the `IsDestRegSet` when unmarshaling the expr bytes. This is now fixed and a small test case is added.

Let me know what think.