### PR TITLE
Fix Objref expression parsing

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -96,6 +96,8 @@ func exprsFromBytes(fam byte, ad *netlink.AttributeDecoder, b []byte) ([]Any, er
 					e = &Cmp{}
 				case "counter":
 					e = &Counter{}
+				case "objref":
+					e = &Objref{}
 				case "payload":
 					e = &Payload{}
 				case "lookup":

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -5567,3 +5567,68 @@ func TestStatelessNAT(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestGetRulesObjref(t *testing.T) {
+	// Create a new network namespace to test these operations,
+	// and tear down the namespace at test completion.
+	c, newNS := openSystemNFTConn(t)
+	defer cleanupSystemNFTConn(t, newNS)
+	// Clear all rules at the beginning + end of the test.
+	c.FlushRuleset()
+	defer c.FlushRuleset()
+
+	table := c.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyIPv4,
+		Name:   "filter",
+	})
+
+	chain := c.AddChain(&nftables.Chain{
+		Name:     "forward",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookForward,
+		Priority: nftables.ChainPriorityFilter,
+	})
+
+	counterName := "fwded1"
+	c.AddObj(&nftables.CounterObj{
+		Table:   table,
+		Name:    counterName,
+		Bytes:   1,
+		Packets: 1,
+	})
+
+	counterRule := c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: []expr.Any{
+			&expr.Objref{
+				Type: 1,
+				Name: counterName,
+			},
+		},
+	})
+
+	if err := c.Flush(); err != nil {
+		t.Errorf("c.Flush() failed: %v", err)
+	}
+
+	rules, err := c.GetRules(table, chain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(rules), 1; got != want {
+		t.Fatalf("unexpected number of rules: got %d, want %d", got, want)
+	}
+	if got, want := len(rules[0].Exprs), 1; got != want {
+		t.Fatalf("unexpected number of exprs: got %d, want %d", got, want)
+	}
+	objref, objrefOk := rules[0].Exprs[0].(*expr.Objref)
+	if !objrefOk {
+		t.Fatalf("Exprs[0] is type %T, want *expr.Objref", rules[0].Exprs[0])
+	}
+	if want := counterRule.Exprs[0]; !reflect.DeepEqual(objref, want) {
+		t.Errorf("objref expr = %+v, wanted %+v", objref, want)
+	}
+}


### PR DESCRIPTION
The Objref expression was not considered when parsing raw expression bytes to construct nftables expressions. As result, rules returned by `GetRules()` didn't included the Objref expression even though the installed nftables rules included it.

For instance, having the following situation:
```
table ip filter { # handle 551
	counter fwded1 { # handle 2
		packets 1 bytes 1
	}

	chain forward { # handle 1
		type filter hook forward priority filter; policy accept;
		counter name "fwded1" # handle 3
	}
}
```
The rule returned by `GetRules()` didn't have expressions:
```
nftables.Rule{
  Table: &nftables.Table{
    Name:   "filter",
    Use:    0x00000000,
    Flags:  0x00000000,
    Family: 0x02,
  },
  Chain: &nftables.Chain{
    Name:     "forward",
    Table:    (*nftables.Table)(nil),
    Hooknum:  (*nftables.ChainHook)(nil),
    Priority: (*nftables.ChainPriority)(nil),
    Type:     "",
    Policy:   (*nftables.ChainPolicy)(nil),
  },
  Position: 0x0000000000000000,
  Handle:   0x0000000000000003,
  Flags:    0x00000000,
  Exprs:    []expr.Any{},
  UserData: []uint8{},
}
```
This PR fixes it and adds an unit test to check that a rule with an Objref expression is properly obtained by `GetRules()`.