### PR TITLE
add int32 and string types to alignedbuff

### DIFF
--- a/alignedbuff/alignedbuff.go
+++ b/alignedbuff/alignedbuff.go
@@ -118,7 +118,7 @@ func (a *AlignedBuff) Uint64() (uint64, error) {
 	return v, nil
 }
 
-// Int32 unmarshals an uint32 in native endianess and alignment. It returns
+// Int32 unmarshals an int32 in native endianess and alignment. It returns
 // ErrEOF when trying to read beyond the payload.
 func (a *AlignedBuff) Int32() (int32, error) {
 	if err := a.alignCheckedRead(int32AlignMask); err != nil {

--- a/binaryutil/binaryutil.go
+++ b/binaryutil/binaryutil.go
@@ -16,6 +16,7 @@
 package binaryutil
 
 import (
+	"bytes"
 	"encoding/binary"
 	"unsafe"
 )
@@ -101,4 +102,23 @@ func (bigEndian) Uint32(b []byte) uint32 {
 
 func (bigEndian) Uint64(b []byte) uint64 {
 	return binary.BigEndian.Uint64(b)
+}
+
+// For dealing with types not supported by the encoding/binary interface
+func PutInt32(v int32) []byte {
+	buf := make([]byte, 4)
+	*(*int32)(unsafe.Pointer(&buf[0])) = v
+	return buf
+}
+
+func Int32(b []byte) int32 {
+	return *(*int32)(unsafe.Pointer(&b[0]))
+}
+
+func PutString(s string) []byte {
+	return []byte(s)
+}
+
+func String(b []byte) string {
+	return string(bytes.TrimRight(b, "\x00"))
 }

--- a/binaryutil/binaryutil.go
+++ b/binaryutil/binaryutil.go
@@ -105,6 +105,7 @@ func (bigEndian) Uint64(b []byte) uint64 {
 }
 
 // For dealing with types not supported by the encoding/binary interface
+
 func PutInt32(v int32) []byte {
 	buf := make([]byte, 4)
 	*(*int32)(unsafe.Pointer(&buf[0])) = v

--- a/binaryutil/binaryutil_test.go
+++ b/binaryutil/binaryutil_test.go
@@ -107,3 +107,43 @@ func TestBigEndian(t *testing.T) {
 		}
 	}
 }
+
+func TestOtherTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		expected  []byte
+		expectedv interface{}
+		actual    []byte
+		unmarshal func(b []byte) interface{}
+	}{
+		{
+			name:      "Int32",
+			expected:  []byte{0x78, 0x56, 0x34, 0x12},
+			expectedv: int32(0x12345678),
+			actual:    PutInt32(0x12345678),
+			unmarshal: func(b []byte) interface{} { return Int32(b) },
+		},
+		{
+			name:      "String",
+			expected:  []byte{0x74, 0x65, 0x73, 0x74},
+			expectedv: "test",
+			actual:    PutString("test"),
+			unmarshal: func(b []byte) interface{} { return String(b) },
+		},
+		{
+			name:      "NullTerminatedString",
+			expected:  []byte{0x74, 0x65, 0x73, 0x74, 0x00},
+			expectedv: "test",
+			actual:    PutNullTerminatedString("test"),
+			unmarshal: func(b []byte) interface{} { return String(b) },
+		},
+	}
+	for _, tt := range tests {
+		if bytes.Compare(tt.actual, tt.expected) != 0 {
+			t.Errorf("Put%s failure, expected: %#v, got: %#v", tt.name, tt.expected, tt.actual)
+		}
+		if actual := tt.unmarshal(tt.actual); !reflect.DeepEqual(actual, tt.expectedv) {
+			t.Errorf("%s failure, expected: %#v, got: %#v", tt.name, tt.expectedv, actual)
+		}
+	}
+}

--- a/binaryutil/binaryutil_test.go
+++ b/binaryutil/binaryutil_test.go
@@ -130,13 +130,6 @@ func TestOtherTypes(t *testing.T) {
 			actual:    PutString("test"),
 			unmarshal: func(b []byte) interface{} { return String(b) },
 		},
-		{
-			name:      "NullTerminatedString",
-			expected:  []byte{0x74, 0x65, 0x73, 0x74, 0x00},
-			expectedv: "test",
-			actual:    PutNullTerminatedString("test"),
-			unmarshal: func(b []byte) interface{} { return String(b) },
-		},
 	}
 	for _, tt := range tests {
 		if bytes.Compare(tt.actual, tt.expected) != 0 {


### PR DESCRIPTION
We use `xt.Unknown` to use xtables matches unsupported directly by this library. To create the correct struct layout we use alignedbuff and binaryutil but a couple of types we need are missing. This PR adds those types and tests. This PR also works in our custom marshaling code for these xtable structs.