### PR TITLE
Fix size for TypeTimeHour

### DIFF
--- a/set.go
+++ b/set.go
@@ -113,7 +113,7 @@ var (
 	TypeIFName      = SetDatatype{Name: "ifname", Bytes: ifNameSize, nftMagic: 41}
 	TypeIGMPType    = SetDatatype{Name: "igmp_type", Bytes: 1, nftMagic: 42}
 	TypeTimeDate    = SetDatatype{Name: "time", Bytes: 8, nftMagic: 43}
-	TypeTimeHour    = SetDatatype{Name: "hour", Bytes: 8, nftMagic: 44}
+	TypeTimeHour    = SetDatatype{Name: "hour", Bytes: 4, nftMagic: 44}
 	TypeTimeDay     = SetDatatype{Name: "day", Bytes: 1, nftMagic: 45}
 	TypeCGroupV2    = SetDatatype{Name: "cgroupsv2", Bytes: 8, nftMagic: 46}
 


### PR DESCRIPTION
Hi,

I have made a small correction in `set.go` for `TypeTimeHour`. The size of the type is set to 8 via `Bytes` field which is incorrect. The correct size should be 4. This is also confirmed in nftables code here: https://git.netfilter.org/nftables/tree/src/meta.c?id=c8a3c669499d169fef8c1e89b8d2d909e5ecd023#n600. The size change was introduced with the following commit: https://git.netfilter.org/nftables/commit/src/meta.c?id=4e1abfc552170d6db5c511634a29918e64c1b51b.

This PR should also fix issue #202.