### PR TITLE
Fix: add NFTA_RULE_COMPAT attribute

### DIFF
--- a/compat_policy.go
+++ b/compat_policy.go
@@ -1,0 +1,89 @@
+package nftables
+
+import (
+	"fmt"
+
+	"github.com/google/nftables/expr"
+	"golang.org/x/sys/unix"
+)
+
+const nft_RULE_COMPAT_F_INV uint32 = (1 << 1)
+const nft_RULE_COMPAT_F_MASK uint32 = nft_RULE_COMPAT_F_INV
+
+// Used by xt match or target like xt_tcpudp to set compat policy between xtables and nftables
+// https://elixir.bootlin.com/linux/v5.12/source/net/netfilter/nft_compat.c#L187
+type compatPolicy struct {
+	Proto uint32
+	Flag  uint32
+}
+
+var xtMatchCompatMap map[string]*compatPolicy = map[string]*compatPolicy{
+	"tcp": {
+		Proto: unix.IPPROTO_TCP,
+	},
+	"udp": {
+		Proto: unix.IPPROTO_UDP,
+	},
+	"udplite": {
+		Proto: unix.IPPROTO_UDPLITE,
+	},
+	"tcpmss": {
+		Proto: unix.IPPROTO_TCP,
+	},
+	"sctp": {
+		Proto: unix.IPPROTO_SCTP,
+	},
+	"osf": {
+		Proto: unix.IPPROTO_TCP,
+	},
+	"ipcomp": {
+		Proto: unix.IPPROTO_COMP,
+	},
+	"esp": {
+		Proto: unix.IPPROTO_ESP,
+	},
+}
+
+var xtTargetCompatMap map[string]*compatPolicy = map[string]*compatPolicy{
+	"TCPOPTSTRIP": {
+		Proto: unix.IPPROTO_TCP,
+	},
+	"TCPMSS": {
+		Proto: unix.IPPROTO_TCP,
+	},
+}
+
+func getCompatPolicy(exprs []expr.Any) (*compatPolicy, error) {
+	var exprItem expr.Any
+	var compat *compatPolicy
+
+	for _, iter := range exprs {
+		var tmpExprItem expr.Any
+		var tmpCompat *compatPolicy
+		switch item := iter.(type) {
+		case *expr.Match:
+			if compat, ok := xtMatchCompatMap[item.Name]; ok {
+				tmpCompat = compat
+				tmpExprItem = item
+			} else {
+				continue
+			}
+		case *expr.Target:
+			if compat, ok := xtTargetCompatMap[item.Name]; ok {
+				tmpCompat = compat
+				tmpExprItem = item
+			} else {
+				continue
+			}
+		default:
+			continue
+		}
+		if compat == nil {
+			compat = tmpCompat
+			exprItem = tmpExprItem
+		} else if *compat != *tmpCompat {
+			return nil, fmt.Errorf("%#v and %#v has conflict compat policy %#v vs %#v", exprItem, tmpExprItem, compat, tmpCompat)
+		}
+	}
+	return compat, nil
+}

--- a/compat_policy_test.go
+++ b/compat_policy_test.go
@@ -1,0 +1,77 @@
+package nftables
+
+import (
+	"testing"
+
+	"github.com/google/nftables/expr"
+	"github.com/google/nftables/xt"
+	"golang.org/x/sys/unix"
+)
+
+func TestGetCompatPolicy(t *testing.T) {
+	// -tcp --dport 0:65534 --sport 0:65534
+	tcpMatch := &expr.Match{
+		Name: "tcp",
+		Info: &xt.Tcp{
+			SrcPorts: [2]uint16{0, 65534},
+			DstPorts: [2]uint16{0, 65534},
+		},
+	}
+
+	// -udp --dport 0:65534 --sport 0:65534
+	udpMatch := &expr.Match{
+		Name: "udp",
+		Info: &xt.Udp{
+			SrcPorts: [2]uint16{0, 65534},
+			DstPorts: [2]uint16{0, 65534},
+		},
+	}
+
+	// -j TCPMSS --set-mss 1460
+	mess := xt.Unknown([]byte{1460 & 0xff, (1460 >> 8) & 0xff})
+	tcpMessTarget := &expr.Target{
+		Name: "TCPMESS",
+		Info: &mess,
+	}
+
+	// -m state --state ESTABLISHED
+	ctMatch := &expr.Match{
+		Name: "conntrack",
+		Rev:  1,
+		Info: &xt.ConntrackMtinfo1{
+			ConntrackMtinfoBase: xt.ConntrackMtinfoBase{
+				MatchFlags: 0x2001,
+			},
+			StateMask: 0x02,
+		},
+	}
+
+	// compatPolicy.Proto should be tcp
+	if compatPolicy, err := getCompatPolicy([]expr.Any{
+		tcpMatch,
+		tcpMessTarget,
+		ctMatch,
+	}); err != nil {
+		t.Fatalf("getCompatPolicy fail %#v", err)
+	} else if compatPolicy.Proto != unix.IPPROTO_TCP {
+		t.Fatalf("getCompatPolicy wrong %#v", compatPolicy)
+	}
+
+	// should conflict
+	if _, err := getCompatPolicy([]expr.Any{
+		udpMatch,
+		tcpMatch,
+	},
+	); err == nil {
+		t.Fatalf("getCompatPolicy fail err should not be nil")
+	}
+
+	// compatPolicy should be nil
+	if compatPolicy, err := getCompatPolicy([]expr.Any{
+		ctMatch,
+	}); err != nil {
+		t.Fatalf("getCompatPolicy fail %#v", err)
+	} else if compatPolicy != nil {
+		t.Fatalf("getCompatPolicy fail compat policy of conntrack match should be nil")
+	}
+}


### PR DESCRIPTION
xt_matches or xt_targets like xt_tcpudp may have specific compat policy and if not set flush rule will error with EINVAL
according to https://elixir.bootlin.com/linux/v3.13/source/net/netfilter/x_tables.c#L563

Signed-off-by: xiaoff <zhaofeng_0019@163.com>