### PR TITLE
Drop unnecessary table rewrite in GetRules()

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -97,9 +97,6 @@ func (cc *Conn) GetRules(t *Table, c *Chain) ([]*Rule, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Carry over all Table attributes (including Family), as the Table
-		// object which ruleFromMsg creates only contains the name.
-		r.Table = t
 		rules = append(rules, r)
 	}
 


### PR DESCRIPTION
Some old kernels (centos-7) send all rules via netlink ignoring table and chain names in GetRules()
There is no way to identify which table and chain contain the rule without this fix.

Moreover, there is no need to rewrite the table after commit 3e042f7