### PR TITLE
Flush: fix error leak when flushing multiple messages in a lasting connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -249,11 +249,16 @@ func (cc *Conn) Flush() error {
 		return fmt.Errorf("SendMessages: %w", err)
 	}
 
+	var errs error
 	// Fetch the requested acknowledgement for each message we sent.
 	for _, msg := range cc.messages {
 		if _, err := receiveAckAware(conn, msg.Header.Flags); err != nil {
-			return fmt.Errorf("conn.Receive: %w", err)
+			errs = errors.Join(errs, err)
 		}
+	}
+
+	if errs != nil {
+		return fmt.Errorf("conn.Receive: %w", errs)
 	}
 
 	return nil


### PR DESCRIPTION
This issue is related to reusing lasting connection after failure on `flush`. 
You start a lasting connection, where you buffer 2+ messages that will fail, then flush these messages which results in failure. But when you reuse this connection to perform an operation which will pass, but `flush` returns back an error although the operation has passed on checking directly with `nft`. Turns out the error was not fully drained from the previous message which leaks into next operation. See pro code to understand -

<details>

<summary>repro</summary>

```go
package main

import (
	"fmt"

	"github.com/google/nftables"
)

func main() {
	conn, err := nftables.New(nftables.AsLasting())
	if err != nil {
		panic(err)
	}
	defer conn.CloseLasting()

	fmt.Println("Flushing and updating a non-existent set which must fail")
	if err := flushAndUpdateSet(conn); err != nil {
		fmt.Printf("[expected] Failed to flushAndUpdateSet: %v\n", err)
	}

	fmt.Println("Create a table must pass")
	if err := createTable(conn); err != nil {
		fmt.Printf("[unexpected] Failed to createTable: %v\n", err)
	}
}

func createTable(conn *nftables.Conn) error {
	table := &nftables.Table{
		Family: nftables.TableFamilyIPv4,
		Name:   "test-table",
	}
	conn.AddTable(table)
	return conn.Flush()
}

func flushAndUpdateSet(conn *nftables.Conn) error {
	set := &nftables.Set{
		Name:    "non-existent-set",
		Table:    &nftables.Table{
			Name:   "non-existent-table",
			Family: nftables.TableFamilyIPv4,
		},
		KeyType: nftables.TypeInteger,
	}

	conn.FlushSet(set)
	if err := conn.SetAddElements(set, []nftables.SetElement{{Key: []byte{0x01, 0x00, 0x00, 0x00}}}); err != nil {
		return err
	}

	return conn.Flush()
}
```
</details>

Repro code does the following:
1) Creates a lasting connection.
2) Flush and Update a non-existent set which must fail.
3) Create a new table using the same existing lasting connection which must pass.

By running the repo code, you notice both ops failed:
```
> nft list ruleset
# emtpy

> ./repro
Flushing and updating a non-existent set which must fail
[expected] Failed to flushAndUpdateSet: conn.Receive: netlink receive: no such file or directory
Create a table must pass
[unexpected] Failed to createTable: conn.Receive: netlink receive: no such file or directory

> nft list ruleset 
table ip test-table {
}

# table creation from repro actually worked, but it still threw an error
```

So repro code produces error for both (2) and (3). When you check in nft ruleset (3) actually succeeded, but repro code returned an error. This happens as errors from (2) were not fully drained from the connection.



