### PR TITLE
Support for quota as object

### DIFF
--- a/obj.go
+++ b/obj.go
@@ -164,6 +164,21 @@ func objFromMsg(msg netlink.Message) (Obj, error) {
 					return o.unmarshal(ad)
 				})
 				return &o, ad.Err()
+			case NFT_OBJECT_QUOTA:
+				o := QuotaObj{
+					Table: table,
+					Name:  name,
+				}
+
+				ad.Do(func(b []byte) error {
+					ad, err := netlink.NewAttributeDecoder(b)
+					if err != nil {
+						return err
+					}
+					ad.ByteOrder = binary.BigEndian
+					return o.unmarshal(ad)
+				})
+				return &o, ad.Err()
 			}
 		}
 	}

--- a/quota.go
+++ b/quota.go
@@ -1,0 +1,80 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"github.com/google/nftables/binaryutil"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	NFTA_OBJ_USERDATA = 8
+	NFT_OBJECT_QUOTA  = 2
+)
+
+type QuotaObj struct {
+	Table    *Table
+	Name     string
+	Bytes    uint64
+	Consumed uint64
+	Over     bool
+}
+
+func (q *QuotaObj) unmarshal(ad *netlink.AttributeDecoder) error {
+	for ad.Next() {
+		switch ad.Type() {
+		case unix.NFTA_QUOTA_BYTES:
+			q.Bytes = ad.Uint64()
+		case unix.NFTA_QUOTA_CONSUMED:
+			q.Consumed = ad.Uint64()
+		case unix.NFTA_QUOTA_FLAGS:
+			q.Over = (ad.Uint32() & unix.NFT_QUOTA_F_INV) == 1
+		}
+	}
+	return nil
+}
+
+func (q *QuotaObj) marshal(data bool) ([]byte, error) {
+	flags := uint32(0)
+	if q.Over {
+		flags = unix.NFT_QUOTA_F_INV
+	}
+	obj, err := netlink.MarshalAttributes([]netlink.Attribute{
+		{Type: unix.NFTA_QUOTA_BYTES, Data: binaryutil.BigEndian.PutUint64(q.Bytes)},
+		{Type: unix.NFTA_QUOTA_CONSUMED, Data: binaryutil.BigEndian.PutUint64(q.Consumed)},
+		{Type: unix.NFTA_QUOTA_FLAGS, Data: binaryutil.BigEndian.PutUint32(flags)},
+	})
+	if err != nil {
+		return nil, err
+	}
+	attrs := []netlink.Attribute{
+		{Type: unix.NFTA_OBJ_TABLE, Data: []byte(q.Table.Name + "\x00")},
+		{Type: unix.NFTA_OBJ_NAME, Data: []byte(q.Name + "\x00")},
+		{Type: unix.NFTA_OBJ_TYPE, Data: binaryutil.BigEndian.PutUint32(NFT_OBJECT_QUOTA)},
+	}
+	if data {
+		attrs = append(attrs, netlink.Attribute{Type: unix.NLA_F_NESTED | unix.NFTA_OBJ_DATA, Data: obj})
+	}
+	return netlink.MarshalAttributes(attrs)
+}
+
+func (q *QuotaObj) table() *Table {
+	return q.Table
+}
+
+func (q *QuotaObj) family() TableFamily {
+	return q.Table.Family
+}


### PR DESCRIPTION
Hi,

I have added support for quota objects as stated in #238. 

One thing to note: I have implemented this object type in a way that aligns with the existing implementation approach of counter object that is already implemented in this lib. It might be good to reconsider the existing implementation approach since object data can be specified as references to existing expression structs implemented in `expr` package and the expression data marshal logic could be reused. At the moment this requires careful rewrite of larger parts of code (`expr.Any` interface where marshaling of the object should be separated from marshaling of the complete expression and `nftables.Obj` interface implementation at the very least) and seems a bit complex since it easily breaks backwards compatibility. Current implementation should work for the time being.

Let me know what you think.