### PR TITLE
NAT: prefix support

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -287,6 +287,8 @@ const (
 	NF_NAT_RANGE_PROTO_RANDOM_FULLY = 0x10
 	// NF_NAT_RANGE_PERSISTENT defines flag for a persistent masquerade
 	NF_NAT_RANGE_PERSISTENT = 0x8
+	// NF_NAT_RANGE_PREFIX defines flag for a prefix masquerade
+	NF_NAT_RANGE_PREFIX = 0x40
 )
 
 func (e *Masq) marshal(fam byte) ([]byte, error) {

--- a/expr/nat.go
+++ b/expr/nat.go
@@ -40,6 +40,7 @@ type NAT struct {
 	Random      bool
 	FullyRandom bool
 	Persistent  bool
+	Prefix      bool
 }
 
 // |00048|N-|00001|	|len |flags| type|
@@ -82,6 +83,9 @@ func (e *NAT) marshal(fam byte) ([]byte, error) {
 	if e.Persistent {
 		flags |= NF_NAT_RANGE_PERSISTENT
 	}
+	if e.Prefix {
+		flags |= NF_NAT_RANGE_PREFIX
+	}
 	if flags != 0 {
 		attrs = append(attrs, netlink.Attribute{Type: unix.NFTA_NAT_FLAGS, Data: binaryutil.BigEndian.PutUint32(flags)})
 	}
@@ -121,6 +125,7 @@ func (e *NAT) unmarshal(fam byte, data []byte) error {
 			e.Persistent = (flags & NF_NAT_RANGE_PERSISTENT) != 0
 			e.Random = (flags & NF_NAT_RANGE_PROTO_RANDOM) != 0
 			e.FullyRandom = (flags & NF_NAT_RANGE_PROTO_RANDOM_FULLY) != 0
+			e.Prefix = (flags & NF_NAT_RANGE_PREFIX) != 0
 		}
 	}
 	return ad.Err()


### PR DESCRIPTION
This PR introduces  inside NAT structure a boolean to enable the **prefix** flag.

This PR refers to the issue #248.

An example about how to use it is the following:

```go
// Copyright 2019-2023 The Liqo Authors
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//      http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

package main

import (
	"encoding/binary"
	"net"

	"github.com/google/nftables"
	"github.com/google/nftables/expr"
)

func main() {
	if err := run(); err != nil {
		panic(err)
	}
}

func run() error {
	nft, err := nftables.New()
	if err != nil {
		return err
	}

	_, subnet, err := net.ParseCIDR("192.168.2.0/24")
	if err != nil {
		return err
	}

	mask := binary.BigEndian.Uint32(subnet.Mask)
	start := binary.BigEndian.Uint32(subnet.IP)

	// find the final address
	lastIP := make(net.IP, 4)
	binary.BigEndian.PutUint32(lastIP, (start&mask)|(mask^0xffffffff))

	table := nft.AddTable(&nftables.Table{
		Name:   "test",
		Family: nftables.TableFamilyIPv4,
	})

	chain := nft.AddChain(&nftables.Chain{
		Name:    "test",
		Table:   table,
		Type:    nftables.ChainTypeNAT,
		Hooknum: nftables.ChainHookPrerouting,
	})

	rule := &nftables.Rule{
		Table: table,
		Chain: chain,
		Exprs: []expr.Any{
			&expr.Immediate{
				Register: 1,
				Data:     subnet.IP,
			},
			&expr.Immediate{
				Register: 2,
				Data:     lastIP,
			},
			&expr.NAT{
				Type:       expr.NATTypeDestNAT,
				RegAddrMin: 1,
				RegAddrMax: 2,
				Prefix:     true,
				Family:     uint32(nftables.TableFamilyIPv4),
			},
		},
	}

	_ = nft.AddTable(table)

	_ = nft.AddChain(chain)

	_ = nft.AddRule(rule)

	return nft.Flush()
}
```