### PR TITLE
Replace TODO const by golang.org/x/sys/unix

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -57,11 +57,10 @@ func (c *CounterObj) marshal(data bool) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	const NFT_OBJECT_COUNTER = 1 // TODO: get into x/sys/unix
 	attrs := []netlink.Attribute{
 		{Type: unix.NFTA_OBJ_TABLE, Data: []byte(c.Table.Name + "\x00")},
 		{Type: unix.NFTA_OBJ_NAME, Data: []byte(c.Name + "\x00")},
-		{Type: unix.NFTA_OBJ_TYPE, Data: binaryutil.BigEndian.PutUint32(NFT_OBJECT_COUNTER)},
+		{Type: unix.NFTA_OBJ_TYPE, Data: binaryutil.BigEndian.PutUint32(unix.NFT_OBJECT_COUNTER)},
 	}
 	if data {
 		attrs = append(attrs, netlink.Attribute{Type: unix.NLA_F_NESTED | unix.NFTA_OBJ_DATA, Data: obj})

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -279,16 +279,15 @@ type Masq struct {
 	RegProtoMax uint32
 }
 
-// TODO, Once the constants below are available in golang.org/x/sys/unix, switch to use those.
 const (
 	// NF_NAT_RANGE_PROTO_RANDOM defines flag for a random masquerade
-	NF_NAT_RANGE_PROTO_RANDOM = 0x4
+	NF_NAT_RANGE_PROTO_RANDOM = unix.NF_NAT_RANGE_PROTO_RANDOM
 	// NF_NAT_RANGE_PROTO_RANDOM_FULLY defines flag for a fully random masquerade
-	NF_NAT_RANGE_PROTO_RANDOM_FULLY = 0x10
+	NF_NAT_RANGE_PROTO_RANDOM_FULLY = unix.NF_NAT_RANGE_PROTO_RANDOM_FULLY
 	// NF_NAT_RANGE_PERSISTENT defines flag for a persistent masquerade
-	NF_NAT_RANGE_PERSISTENT = 0x8
+	NF_NAT_RANGE_PERSISTENT = unix.NF_NAT_RANGE_PERSISTENT
 	// NF_NAT_RANGE_PREFIX defines flag for a prefix masquerade
-	NF_NAT_RANGE_PREFIX = 0x40
+	NF_NAT_RANGE_PREFIX = unix.NF_NAT_RANGE_NETMAP
 )
 
 func (e *Masq) marshal(fam byte) ([]byte, error) {

--- a/expr/queue.go
+++ b/expr/queue.go
@@ -32,10 +32,9 @@ const (
 	QueueTotal QueueAttribute = unix.NFTA_QUEUE_TOTAL
 	QueueFlags QueueAttribute = unix.NFTA_QUEUE_FLAGS
 
-	// TODO: get into x/sys/unix
-	QueueFlagBypass QueueFlag = 0x01
-	QueueFlagFanout QueueFlag = 0x02
-	QueueFlagMask   QueueFlag = 0x03
+	QueueFlagBypass QueueFlag = unix.NFT_QUEUE_FLAG_BYPASS
+	QueueFlagFanout QueueFlag = unix.NFT_QUEUE_FLAG_CPU_FANOUT
+	QueueFlagMask   QueueFlag = unix.NFT_QUEUE_FLAG_MASK
 )
 
 type Queue struct {

--- a/obj.go
+++ b/obj.go
@@ -141,7 +141,6 @@ func objFromMsg(msg netlink.Message) (Obj, error) {
 		name       string
 		objectType uint32
 	)
-	const NFT_OBJECT_COUNTER = 1 // TODO: get into x/sys/unix
 	for ad.Next() {
 		switch ad.Type() {
 		case unix.NFTA_OBJ_TABLE:
@@ -152,7 +151,7 @@ func objFromMsg(msg netlink.Message) (Obj, error) {
 			objectType = ad.Uint32()
 		case unix.NFTA_OBJ_DATA:
 			switch objectType {
-			case NFT_OBJECT_COUNTER:
+			case unix.NFT_OBJECT_COUNTER:
 				o := CounterObj{
 					Table: table,
 					Name:  name,


### PR DESCRIPTION
Replace some hardcoded consts by the ones provided in golang.org/x/sys/unix