### PR TITLE
Objects implementation refactor

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -259,7 +259,7 @@ func (monitor *Monitor) monitor() {
 				}
 				monitor.eventCh <- event
 			case unix.NFT_MSG_NEWOBJ, unix.NFT_MSG_DELOBJ:
-				obj, err := objFromMsg(msg)
+				obj, err := objFromMsg(msg, true)
 				event := &MonitorEvent{
 					Type:  MonitorEventType(msgType),
 					Data:  obj,

--- a/obj.go
+++ b/obj.go
@@ -18,6 +18,9 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
+	"github.com/google/nftables/internal/parseexprfunc"
 	"github.com/mdlayher/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -27,13 +30,73 @@ var (
 	delObjHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELOBJ)
 )
 
+type ObjType uint32
+
+// https://git.netfilter.org/libnftnl/tree/include/linux/netfilter/nf_tables.h?id=be0bae0ad31b0adb506f96de083f52a2bd0d4fbf#n1612
+const (
+	ObjTypeCounter   ObjType = unix.NFT_OBJECT_COUNTER
+	ObjTypeQuota     ObjType = unix.NFT_OBJECT_QUOTA
+	ObjTypeCtHelper  ObjType = unix.NFT_OBJECT_CT_HELPER
+	ObjTypeLimit     ObjType = unix.NFT_OBJECT_LIMIT
+	ObjTypeConnLimit ObjType = unix.NFT_OBJECT_CONNLIMIT
+	ObjTypeTunnel    ObjType = unix.NFT_OBJECT_TUNNEL
+	ObjTypeCtTimeout ObjType = unix.NFT_OBJECT_CT_TIMEOUT
+	ObjTypeSecMark   ObjType = unix.NFT_OBJECT_SECMARK
+	ObjTypeCtExpect  ObjType = unix.NFT_OBJECT_CT_EXPECT
+	ObjTypeSynProxy  ObjType = unix.NFT_OBJECT_SYNPROXY
+)
+
+var objByObjTypeMagic = map[ObjType]string{
+	ObjTypeCounter:   "counter",
+	ObjTypeQuota:     "quota",
+	ObjTypeLimit:     "limit",
+	ObjTypeConnLimit: "connlimit",
+	ObjTypeCtHelper:  "cthelper",  // not implemented in expr
+	ObjTypeTunnel:    "tunnel",    // not implemented in expr
+	ObjTypeCtTimeout: "cttimeout", // not implemented in expr
+	ObjTypeSecMark:   "secmark",   // not implemented in expr
+	ObjTypeCtExpect:  "ctexpect",  // not implemented in expr
+	ObjTypeSynProxy:  "synproxy",  // not implemented in expr
+}
+
 // Obj represents a netfilter stateful object. See also
 // https://wiki.nftables.org/wiki-nftables/index.php/Stateful_objects
 type Obj interface {
 	table() *Table
 	family() TableFamily
-	unmarshal(*netlink.AttributeDecoder) error
-	marshal(data bool) ([]byte, error)
+	data() expr.Any
+	name() string
+	objType() ObjType
+}
+
+// NamedObj represents nftables stateful object attributes
+// Corresponds to netfilter nft_object_attributes as per
+// https://git.netfilter.org/libnftnl/tree/include/linux/netfilter/nf_tables.h?id=116e95aa7b6358c917de8c69f6f173874030b46b#n1626
+type NamedObj struct {
+	Table *Table
+	Name  string
+	Type  ObjType
+	Obj   expr.Any
+}
+
+func (o *NamedObj) table() *Table {
+	return o.Table
+}
+
+func (o *NamedObj) family() TableFamily {
+	return o.Table.Family
+}
+
+func (o *NamedObj) data() expr.Any {
+	return o.Obj
+}
+
+func (o *NamedObj) name() string {
+	return o.Name
+}
+
+func (o *NamedObj) objType() ObjType {
+	return o.Type
 }
 
 // AddObject adds the specified Obj. Alias of AddObj.
@@ -46,10 +109,19 @@ func (cc *Conn) AddObject(o Obj) Obj {
 func (cc *Conn) AddObj(o Obj) Obj {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
-	data, err := o.marshal(true)
+	data, err := expr.MarshalExprData(byte(o.family()), o.data())
 	if err != nil {
 		cc.setErr(err)
 		return nil
+	}
+
+	attrs := []netlink.Attribute{
+		{Type: unix.NFTA_OBJ_TABLE, Data: []byte(o.table().Name + "\x00")},
+		{Type: unix.NFTA_OBJ_NAME, Data: []byte(o.name() + "\x00")},
+		{Type: unix.NFTA_OBJ_TYPE, Data: binaryutil.BigEndian.PutUint32(uint32(o.objType()))},
+	}
+	if len(data) > 0 {
+		attrs = append(attrs, netlink.Attribute{Type: unix.NLA_F_NESTED | unix.NFTA_OBJ_DATA, Data: data})
 	}
 
 	cc.messages = append(cc.messages, netlink.Message{
@@ -57,7 +129,7 @@ func (cc *Conn) AddObj(o Obj) Obj {
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWOBJ),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
 		},
-		Data: append(extraHeader(uint8(o.family()), 0), data...),
+		Data: append(extraHeader(uint8(o.family()), 0), cc.marshalAttr(attrs)...),
 	})
 	return o
 }
@@ -66,12 +138,12 @@ func (cc *Conn) AddObj(o Obj) Obj {
 func (cc *Conn) DeleteObject(o Obj) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
-	data, err := o.marshal(false)
-	if err != nil {
-		cc.setErr(err)
-		return
+	attrs := []netlink.Attribute{
+		{Type: unix.NFTA_OBJ_TABLE, Data: []byte(o.table().Name + "\x00")},
+		{Type: unix.NFTA_OBJ_NAME, Data: []byte(o.name() + "\x00")},
+		{Type: unix.NFTA_OBJ_TYPE, Data: binaryutil.BigEndian.PutUint32(uint32(o.objType()))},
 	}
-
+	data := cc.marshalAttr(attrs)
 	data = append(data, cc.marshalAttr([]netlink.Attribute{{Type: unix.NLA_F_NESTED | unix.NFTA_OBJ_DATA}})...)
 
 	cc.messages = append(cc.messages, netlink.Message{
@@ -85,17 +157,26 @@ func (cc *Conn) DeleteObject(o Obj) {
 
 // GetObj is a legacy method that return all Obj that belongs
 // to the same table as the given one
+// This function returns the same concrete type as passed,
+// e.g. QuotaObj, CounterObj or NamedObj. Prefer using the more
+// generic NamedObj over the legacy QuotaObj and CounterObj types.
 func (cc *Conn) GetObj(o Obj) ([]Obj, error) {
-	return cc.getObj(nil, o.table(), unix.NFT_MSG_GETOBJ)
+	return cc.getObjWithLegacyType(nil, o.table(), unix.NFT_MSG_GETOBJ, cc.useLegacyObjType(o))
 }
 
 // GetObjReset is a legacy method that reset all Obj that belongs
 // the same table as the given one
+// This function returns the same concrete type as passed,
+// e.g. QuotaObj, CounterObj or NamedObj. Prefer using the more
+// generic NamedObj over the legacy QuotaObj and CounterObj types.
 func (cc *Conn) GetObjReset(o Obj) ([]Obj, error) {
-	return cc.getObj(nil, o.table(), unix.NFT_MSG_GETOBJ_RESET)
+	return cc.getObjWithLegacyType(nil, o.table(), unix.NFT_MSG_GETOBJ_RESET, cc.useLegacyObjType(o))
 }
 
 // GetObject gets the specified Object
+// This function returns the same concrete type as passed,
+// e.g. QuotaObj, CounterObj or NamedObj. Prefer using the more
+// generic NamedObj over the legacy QuotaObj and CounterObj types.
 func (cc *Conn) GetObject(o Obj) (Obj, error) {
 	objs, err := cc.getObj(o, o.table(), unix.NFT_MSG_GETOBJ)
 
@@ -107,11 +188,16 @@ func (cc *Conn) GetObject(o Obj) (Obj, error) {
 }
 
 // GetObjects get all the Obj that belongs to the given table
+// This function will always return legacy QuotaObj/CounterObj
+// types for backwards compatibility
 func (cc *Conn) GetObjects(t *Table) ([]Obj, error) {
 	return cc.getObj(nil, t, unix.NFT_MSG_GETOBJ)
 }
 
 // ResetObject reset the given Obj
+// This function returns the same concrete type as passed,
+// e.g. QuotaObj, CounterObj or NamedObj. Prefer using the more
+// generic NamedObj over the legacy QuotaObj and CounterObj types.
 func (cc *Conn) ResetObject(o Obj) (Obj, error) {
 	objs, err := cc.getObj(o, o.table(), unix.NFT_MSG_GETOBJ_RESET)
 
@@ -123,11 +209,13 @@ func (cc *Conn) ResetObject(o Obj) (Obj, error) {
 }
 
 // ResetObjects reset all the Obj that belongs to the given table
+// This function will always return legacy QuotaObj/CounterObj
+// types for backwards compatibility
 func (cc *Conn) ResetObjects(t *Table) ([]Obj, error) {
 	return cc.getObj(nil, t, unix.NFT_MSG_GETOBJ_RESET)
 }
 
-func objFromMsg(msg netlink.Message) (Obj, error) {
+func objFromMsg(msg netlink.Message, returnLegacyType bool) (Obj, error) {
 	if got, want1, want2 := msg.Header.Type, newObjHeaderType, delObjHeaderType; got != want1 && got != want2 {
 		return nil, fmt.Errorf("unexpected header type: got %v, want %v or %v", got, want1, want2)
 	}
@@ -150,38 +238,30 @@ func objFromMsg(msg netlink.Message) (Obj, error) {
 		case unix.NFTA_OBJ_TYPE:
 			objectType = ad.Uint32()
 		case unix.NFTA_OBJ_DATA:
-			switch objectType {
-			case unix.NFT_OBJECT_COUNTER:
-				o := CounterObj{
-					Table: table,
-					Name:  name,
-				}
-
-				ad.Do(func(b []byte) error {
-					ad, err := netlink.NewAttributeDecoder(b)
-					if err != nil {
-						return err
-					}
-					ad.ByteOrder = binary.BigEndian
-					return o.unmarshal(ad)
-				})
-				return &o, ad.Err()
-			case NFT_OBJECT_QUOTA:
-				o := QuotaObj{
-					Table: table,
-					Name:  name,
-				}
-
-				ad.Do(func(b []byte) error {
-					ad, err := netlink.NewAttributeDecoder(b)
-					if err != nil {
-						return err
-					}
-					ad.ByteOrder = binary.BigEndian
-					return o.unmarshal(ad)
-				})
-				return &o, ad.Err()
+			if returnLegacyType {
+				return objDataFromMsgLegacy(ad, table, name, objectType)
 			}
+
+			o := NamedObj{
+				Table: table,
+				Name:  name,
+				Type:  ObjType(objectType),
+			}
+
+			objs, err := parseexprfunc.ParseExprBytesFromNameFunc(byte(o.family()), ad, objByObjTypeMagic[o.Type])
+			if err != nil {
+				return nil, err
+			}
+			if len(objs) == 0 {
+				return nil, fmt.Errorf("objFromMsg: objs is empty for obj %v", o)
+			}
+			exprs := make([]expr.Any, len(objs))
+			for i := range exprs {
+				exprs[i] = objs[i].(expr.Any)
+			}
+
+			o.Obj = exprs[0]
+			return &o, ad.Err()
 		}
 	}
 	if err := ad.Err(); err != nil {
@@ -190,7 +270,50 @@ func objFromMsg(msg netlink.Message) (Obj, error) {
 	return nil, fmt.Errorf("malformed stateful object")
 }
 
+func objDataFromMsgLegacy(ad *netlink.AttributeDecoder, table *Table, name string, objectType uint32) (Obj, error) {
+	switch objectType {
+	case unix.NFT_OBJECT_COUNTER:
+		o := CounterObj{
+			Table: table,
+			Name:  name,
+		}
+
+		ad.Do(func(b []byte) error {
+			ad, err := netlink.NewAttributeDecoder(b)
+			if err != nil {
+				return err
+			}
+			ad.ByteOrder = binary.BigEndian
+			return o.unmarshal(ad)
+		})
+		return &o, ad.Err()
+	case unix.NFT_OBJECT_QUOTA:
+		o := QuotaObj{
+			Table: table,
+			Name:  name,
+		}
+
+		ad.Do(func(b []byte) error {
+			ad, err := netlink.NewAttributeDecoder(b)
+			if err != nil {
+				return err
+			}
+			ad.ByteOrder = binary.BigEndian
+			return o.unmarshal(ad)
+		})
+		return &o, ad.Err()
+	}
+	if err := ad.Err(); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("malformed stateful object")
+}
+
 func (cc *Conn) getObj(o Obj, t *Table, msgType uint16) ([]Obj, error) {
+	return cc.getObjWithLegacyType(o, t, msgType, cc.useLegacyObjType(o))
+}
+
+func (cc *Conn) getObjWithLegacyType(o Obj, t *Table, msgType uint16, returnLegacyObjType bool) ([]Obj, error) {
 	conn, closer, err := cc.netlinkConn()
 	if err != nil {
 		return nil, err
@@ -201,7 +324,12 @@ func (cc *Conn) getObj(o Obj, t *Table, msgType uint16) ([]Obj, error) {
 	var flags netlink.HeaderFlags
 
 	if o != nil {
-		data, err = o.marshal(false)
+		attrs := []netlink.Attribute{
+			{Type: unix.NFTA_OBJ_TABLE, Data: []byte(o.table().Name + "\x00")},
+			{Type: unix.NFTA_OBJ_NAME, Data: []byte(o.name() + "\x00")},
+			{Type: unix.NFTA_OBJ_TYPE, Data: binaryutil.BigEndian.PutUint32(uint32(o.objType()))},
+		}
+		data = cc.marshalAttr(attrs)
 	} else {
 		flags = netlink.Dump
 		data, err = netlink.MarshalAttributes([]netlink.Attribute{
@@ -230,7 +358,7 @@ func (cc *Conn) getObj(o Obj, t *Table, msgType uint16) ([]Obj, error) {
 	}
 	var objs []Obj
 	for _, msg := range reply {
-		o, err := objFromMsg(msg)
+		o, err := objFromMsg(msg, returnLegacyObjType)
 		if err != nil {
 			return nil, err
 		}
@@ -238,4 +366,15 @@ func (cc *Conn) getObj(o Obj, t *Table, msgType uint16) ([]Obj, error) {
 	}
 
 	return objs, nil
+}
+
+func (cc *Conn) useLegacyObjType(o Obj) bool {
+	useLegacyType := true
+	if o != nil {
+		switch o.(type) {
+		case *NamedObj:
+			useLegacyType = false
+		}
+	}
+	return useLegacyType
 }

--- a/quota.go
+++ b/quota.go
@@ -15,14 +15,9 @@
 package nftables
 
 import (
-	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
 	"github.com/mdlayher/netlink"
 	"golang.org/x/sys/unix"
-)
-
-const (
-	NFTA_OBJ_USERDATA = 8
-	NFT_OBJECT_QUOTA  = 2
 )
 
 type QuotaObj struct {
@@ -47,34 +42,26 @@ func (q *QuotaObj) unmarshal(ad *netlink.AttributeDecoder) error {
 	return nil
 }
 
-func (q *QuotaObj) marshal(data bool) ([]byte, error) {
-	flags := uint32(0)
-	if q.Over {
-		flags = unix.NFT_QUOTA_F_INV
-	}
-	obj, err := netlink.MarshalAttributes([]netlink.Attribute{
-		{Type: unix.NFTA_QUOTA_BYTES, Data: binaryutil.BigEndian.PutUint64(q.Bytes)},
-		{Type: unix.NFTA_QUOTA_CONSUMED, Data: binaryutil.BigEndian.PutUint64(q.Consumed)},
-		{Type: unix.NFTA_QUOTA_FLAGS, Data: binaryutil.BigEndian.PutUint32(flags)},
-	})
-	if err != nil {
-		return nil, err
-	}
-	attrs := []netlink.Attribute{
-		{Type: unix.NFTA_OBJ_TABLE, Data: []byte(q.Table.Name + "\x00")},
-		{Type: unix.NFTA_OBJ_NAME, Data: []byte(q.Name + "\x00")},
-		{Type: unix.NFTA_OBJ_TYPE, Data: binaryutil.BigEndian.PutUint32(NFT_OBJECT_QUOTA)},
-	}
-	if data {
-		attrs = append(attrs, netlink.Attribute{Type: unix.NLA_F_NESTED | unix.NFTA_OBJ_DATA, Data: obj})
-	}
-	return netlink.MarshalAttributes(attrs)
-}
-
 func (q *QuotaObj) table() *Table {
 	return q.Table
 }
 
 func (q *QuotaObj) family() TableFamily {
 	return q.Table.Family
+}
+
+func (q *QuotaObj) data() expr.Any {
+	return &expr.Quota{
+		Bytes:    q.Bytes,
+		Consumed: q.Consumed,
+		Over:     q.Over,
+	}
+}
+
+func (q *QuotaObj) name() string {
+	return q.Name
+}
+
+func (q *QuotaObj) objType() ObjType {
+	return ObjTypeQuota
 }


### PR DESCRIPTION
Hi,

as per our discussion in #253, I have implemented a change for a more generic implementation of nftables objects. In addition to the refactor I have added a test to demonstrate that already implemented expressions are now supported as objects and made a few lint changes. Note that some of the expressions are currently not implemented in the lib (i.e. synproxy, ct_helper, ct_expect, ...). These can now be easily added to the `expr` package to offer support. I'll see to adding them after we agree on this refactor change.

Let me know what you think.