### PR TITLE
Added GetNamedObjects and ResetNamedObjects

### DIFF
--- a/obj.go
+++ b/obj.go
@@ -194,6 +194,12 @@ func (cc *Conn) GetObjects(t *Table) ([]Obj, error) {
 	return cc.getObj(nil, t, unix.NFT_MSG_GETOBJ)
 }
 
+// GetNamedObjects get all the Obj that belongs to the given table
+// This function always return NamedObj types
+func (cc *Conn) GetNamedObjects(t *Table) ([]Obj, error) {
+	return cc.getObjWithLegacyType(nil, t, unix.NFT_MSG_GETOBJ, false)
+}
+
 // ResetObject reset the given Obj
 // This function returns the same concrete type as passed,
 // e.g. QuotaObj, CounterObj or NamedObj. Prefer using the more
@@ -213,6 +219,12 @@ func (cc *Conn) ResetObject(o Obj) (Obj, error) {
 // types for backwards compatibility
 func (cc *Conn) ResetObjects(t *Table) ([]Obj, error) {
 	return cc.getObj(nil, t, unix.NFT_MSG_GETOBJ_RESET)
+}
+
+// ResetNamedObjects reset all the Obj that belongs to the given table
+// This function always return NamedObj types
+func (cc *Conn) ResetNamedObjects(t *Table) ([]Obj, error) {
+	return cc.getObjWithLegacyType(nil, t, unix.NFT_MSG_GETOBJ_RESET, false)
 }
 
 func objFromMsg(msg netlink.Message, returnLegacyType bool) (Obj, error) {


### PR DESCRIPTION
Hi,

now that NamedObj type is implemented we would need to introduce new variant of `GetObjects(table)` and `ResetObjects(table)` funcs as current ones work only with legacy QuotaObj and CounterObj types. This PR introduces `GetNamedObjects(table)` and `ResetNamedObjects(table)` funcs which work only with the new NamedObj type.

Let me know what you think.