### PR TITLE
Implement cthelper object expr

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -197,6 +197,8 @@ func exprFromName(name string) Any {
 		e = &Masq{}
 	case "hash":
 		e = &Hash{}
+	case "cthelper":
+		e = &CtHelper{}
 	}
 	return e
 }

--- a/obj.go
+++ b/obj.go
@@ -51,7 +51,7 @@ var objByObjTypeMagic = map[ObjType]string{
 	ObjTypeQuota:     "quota",
 	ObjTypeLimit:     "limit",
 	ObjTypeConnLimit: "connlimit",
-	ObjTypeCtHelper:  "cthelper",  // not implemented in expr
+	ObjTypeCtHelper:  "cthelper",
 	ObjTypeTunnel:    "tunnel",    // not implemented in expr
 	ObjTypeCtTimeout: "cttimeout", // not implemented in expr
 	ObjTypeSecMark:   "secmark",   // not implemented in expr


### PR DESCRIPTION
As discussed in NamedObj PR, there are some expression types missing in expr package for object feature to be complete. This PR implements ObjTypeCtHelper. Plan is to implement the remaining ones afterwards so let me know if it is OK to introduce separate PR for each type.

Thanks!