### PR TITLE
Fix: NFT_DYNSET_F_EXPR not supported for kernels < 5.11-rc3

### DIFF
--- a/expr/dynset.go
+++ b/expr/dynset.go
@@ -77,7 +77,6 @@ func (e *Dynset) marshalData(fam byte) ([]byte, error) {
 
 	// Per https://git.netfilter.org/libnftnl/tree/src/expr/dynset.c?id=84d12cfacf8ddd857a09435f3d982ab6250d250c#n170
 	if len(e.Exprs) > 0 {
-		flags |= NFT_DYNSET_F_EXPR
 		switch len(e.Exprs) {
 		case 1:
 			exprData, err := Marshal(fam, e.Exprs[0])
@@ -86,6 +85,7 @@ func (e *Dynset) marshalData(fam byte) ([]byte, error) {
 			}
 			opAttrs = append(opAttrs, netlink.Attribute{Type: unix.NFTA_DYNSET_EXPR, Data: exprData})
 		default:
+			flags |= NFT_DYNSET_F_EXPR
 			var elemAttrs []netlink.Attribute
 			for _, ex := range e.Exprs {
 				exprData, err := Marshal(fam, ex)


### PR DESCRIPTION
Hi! 

We noticed that `NFT_DYNSET_F_EXPR` flag added in [v5.11-rc3](https://elixir.bootlin.com/linux/v5.11-rc3/source/include/uapi/linux/netfilter/nf_tables.h#L711)  is also used with kernels which don't support [NFTA_DYNSET_EXPRESSIONS](https://elixir.bootlin.com/linux/v5.11-rc1/source/net/netfilter/nft_dynset.c#L259) (`<v5.11-rc1`). The flag was added in the [patchset](https://lore.kernel.org/all/20210103192920.18639-1-pablo@netfilter.org/#R) not to fail silently. 

The described [behavior](https://elixir.bootlin.com/linux/v5.10.225/source/net/netfilter/nft_dynset.c#L129) causes error for older kernels, what this contribution aims to fix.