### PR TITLE
Add: netlink socket options

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -298,7 +298,7 @@ func (cc *Conn) FlushRuleset() {
 func (cc *Conn) dialNetlink() (*netlink.Conn, error) {
 	var (
 		conn *netlink.Conn
-		err  error = nil
+		err  error
 	)
 
 	if cc.TestDial != nil {
@@ -312,9 +312,7 @@ func (cc *Conn) dialNetlink() (*netlink.Conn, error) {
 	}
 
 	for _, opt := range cc.sockOptions {
-		err := opt(conn)
-
-		if err != nil {
+		if err := opt(conn); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Hi!

While using nftables we understood that it would be great to be able to set some options on the socket, i.e. setting r/w buffer size or `pid` retrieval to track what process issues rule changes. 

This PR attemps to add such api to the `New` method through options (callbacks) executed every time `dialNetlink` called.