### PR TITLE
Update: process monitor events all at once upon commit

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1,0 +1,45 @@
+package nftables
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type GenMsg struct {
+	ID       uint32
+	ProcPID  uint32
+	ProcComm string // [16]byte - max 16bytes - kernel TASK_COMM_LEN
+}
+
+var genHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWGEN)
+
+func genFromMsg(msg netlink.Message) (*GenMsg, error) {
+	if got, want := msg.Header.Type, genHeaderType; got != want {
+		return nil, fmt.Errorf("unexpected header type: got %v, want %v", got, want)
+	}
+	ad, err := netlink.NewAttributeDecoder(msg.Data[4:])
+	if err != nil {
+		return nil, err
+	}
+	ad.ByteOrder = binary.BigEndian
+
+	msgOut := &GenMsg{}
+	for ad.Next() {
+		switch ad.Type() {
+		case unix.NFTA_GEN_ID:
+			msgOut.ID = ad.Uint32()
+		case unix.NFTA_GEN_PROC_PID:
+			msgOut.ProcPID = ad.Uint32()
+		case unix.NFTA_GEN_PROC_NAME:
+			msgOut.ProcComm = ad.String()
+		default:
+			return nil, fmt.Errorf("Unknown attribute: %d %v\n", ad.Type(), ad.Bytes())
+		}
+	}
+	if err := ad.Err(); err != nil {
+		return nil, err
+	}
+	return msgOut, nil
+}

--- a/monitor.go
+++ b/monitor.go
@@ -302,7 +302,7 @@ func (monitor *Monitor) monitor() {
 					Changes:     changesEvents,
 				}
 
-				changesEvents = make([]*MonitorEvent, 0)
+				changesEvents = nil
 			}
 		}
 	}

--- a/monitor.go
+++ b/monitor.go
@@ -198,7 +198,7 @@ func NewMonitor(opts ...MonitorOption) *Monitor {
 }
 
 func (monitor *Monitor) monitor() {
-	changesEvents := make([]*MonitorEvent, 0)
+	var changesEvents []*MonitorEvent
 
 	for {
 		msgs, err := monitor.conn.Receive()
@@ -220,7 +220,7 @@ func (monitor *Monitor) monitor() {
 					GeneratedBy: event,
 					Changes:     changesEvents,
 				}
-				changesEvents = make([]*MonitorEvent, 0)
+				changesEvents = nil
 
 				break
 			}
@@ -333,7 +333,6 @@ func (monitor *Monitor) Close() error {
 // handle, for now.
 func (cc *Conn) AddMonitor(monitor *Monitor) (chan *MonitorEvent, error) {
 	generationalEventCh, err := cc.AddGenerationalMonitor(monitor)
-
 	if err != nil {
 		return nil, err
 	}

--- a/monitor.go
+++ b/monitor.go
@@ -116,9 +116,15 @@ const (
 // nftables.MonitorEventTypeNewTable, you can access the corresponding table
 // details via Data.(*nftables.Table).
 type MonitorEvent struct {
-	Type  MonitorEventType
-	Data  any
-	Error error
+	Header netlink.Header
+	Type   MonitorEventType
+	Data   any
+	Error  error
+}
+
+type MonitorEvents struct {
+	GenerateBy *MonitorEvent
+	Changes    []*MonitorEvent
 }
 
 const (
@@ -139,7 +145,7 @@ type Monitor struct {
 
 	// mu covers eventCh and status
 	mu      sync.Mutex
-	eventCh chan *MonitorEvent
+	eventCh chan *MonitorEvents
 	status  int
 }
 
@@ -147,7 +153,7 @@ type MonitorOption func(*Monitor)
 
 func WithMonitorEventBuffer(size int) MonitorOption {
 	return func(monitor *Monitor) {
-		monitor.eventCh = make(chan *MonitorEvent, size)
+		monitor.eventCh = make(chan *MonitorEvents, size)
 	}
 }
 
@@ -177,7 +183,7 @@ func NewMonitor(opts ...MonitorOption) *Monitor {
 		opt(monitor)
 	}
 	if monitor.eventCh == nil {
-		monitor.eventCh = make(chan *MonitorEvent)
+		monitor.eventCh = make(chan *MonitorEvents)
 	}
 	objects, ok := monitorFlags[monitor.action]
 	if !ok {
@@ -192,6 +198,8 @@ func NewMonitor(opts ...MonitorOption) *Monitor {
 }
 
 func (monitor *Monitor) monitor() {
+	changesEvents := make([]*MonitorEvent, 0, 2)
+
 	for {
 		msgs, err := monitor.conn.Receive()
 		if err != nil {
@@ -199,13 +207,21 @@ func (monitor *Monitor) monitor() {
 				// ignore the error that be closed
 				break
 			} else {
-				// any other errors will be send to user, and then to close eventCh
+				// any other errors will be sent to user, and then to close eventCh
 				event := &MonitorEvent{
 					Type:  MonitorEventTypeOOB,
 					Data:  nil,
 					Error: err,
 				}
-				monitor.eventCh <- event
+
+				changesEvents = append(changesEvents, event)
+
+				monitor.eventCh <- &MonitorEvents{
+					GenerateBy: event,
+					Changes:    changesEvents,
+				}
+				changesEvents = make([]*MonitorEvent, 0, 2)
+
 				break
 			}
 		}
@@ -221,54 +237,76 @@ func (monitor *Monitor) monitor() {
 			case unix.NFT_MSG_NEWTABLE, unix.NFT_MSG_DELTABLE:
 				table, err := tableFromMsg(msg)
 				event := &MonitorEvent{
-					Type:  MonitorEventType(msgType),
-					Data:  table,
-					Error: err,
+					Type:   MonitorEventType(msgType),
+					Data:   table,
+					Error:  err,
+					Header: msg.Header,
 				}
-				monitor.eventCh <- event
+				changesEvents = append(changesEvents, event)
 			case unix.NFT_MSG_NEWCHAIN, unix.NFT_MSG_DELCHAIN:
 				chain, err := chainFromMsg(msg)
 				event := &MonitorEvent{
-					Type:  MonitorEventType(msgType),
-					Data:  chain,
-					Error: err,
+					Type:   MonitorEventType(msgType),
+					Data:   chain,
+					Error:  err,
+					Header: msg.Header,
 				}
-				monitor.eventCh <- event
+				changesEvents = append(changesEvents, event)
 			case unix.NFT_MSG_NEWRULE, unix.NFT_MSG_DELRULE:
 				rule, err := parseRuleFromMsg(msg)
 				event := &MonitorEvent{
-					Type:  MonitorEventType(msgType),
-					Data:  rule,
-					Error: err,
+					Type:   MonitorEventType(msgType),
+					Data:   rule,
+					Error:  err,
+					Header: msg.Header,
 				}
-				monitor.eventCh <- event
+				changesEvents = append(changesEvents, event)
 			case unix.NFT_MSG_NEWSET, unix.NFT_MSG_DELSET:
 				set, err := setsFromMsg(msg)
 				event := &MonitorEvent{
-					Type:  MonitorEventType(msgType),
-					Data:  set,
-					Error: err,
+					Type:   MonitorEventType(msgType),
+					Data:   set,
+					Error:  err,
+					Header: msg.Header,
 				}
-				monitor.eventCh <- event
+				changesEvents = append(changesEvents, event)
 			case unix.NFT_MSG_NEWSETELEM, unix.NFT_MSG_DELSETELEM:
 				elems, err := elementsFromMsg(uint8(TableFamilyUnspecified), msg)
 				event := &MonitorEvent{
-					Type:  MonitorEventType(msgType),
-					Data:  elems,
-					Error: err,
+					Type:   MonitorEventType(msgType),
+					Data:   elems,
+					Error:  err,
+					Header: msg.Header,
 				}
-				monitor.eventCh <- event
+				changesEvents = append(changesEvents, event)
 			case unix.NFT_MSG_NEWOBJ, unix.NFT_MSG_DELOBJ:
 				obj, err := objFromMsg(msg, true)
 				event := &MonitorEvent{
-					Type:  MonitorEventType(msgType),
-					Data:  obj,
-					Error: err,
+					Type:   MonitorEventType(msgType),
+					Data:   obj,
+					Error:  err,
+					Header: msg.Header,
 				}
-				monitor.eventCh <- event
+				changesEvents = append(changesEvents, event)
+			case unix.NFT_MSG_NEWGEN:
+				gen, err := genFromMsg(msg)
+				event := &MonitorEvent{
+					Type:   MonitorEventType(msgType),
+					Data:   gen,
+					Error:  err,
+					Header: msg.Header,
+				}
+
+				monitor.eventCh <- &MonitorEvents{
+					GenerateBy: event,
+					Changes:    changesEvents,
+				}
+
+				changesEvents = make([]*MonitorEvent, 0, 2)
 			}
 		}
 	}
+
 	monitor.mu.Lock()
 	defer monitor.mu.Unlock()
 
@@ -293,7 +331,7 @@ func (monitor *Monitor) Close() error {
 // calling Close on Monitor or encountering a netlink conn error while Receive.
 // Caller may receive a MonitorEventTypeOOB event which contains an error we didn't
 // handle, for now.
-func (cc *Conn) AddMonitor(monitor *Monitor) (chan *MonitorEvent, error) {
+func (cc *Conn) AddMonitor(monitor *Monitor) (chan *MonitorEvents, error) {
 	conn, closer, err := cc.netlinkConn()
 	if err != nil {
 		return nil, err

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -21,7 +21,7 @@ func ExampleNewMonitor() {
 
 	mon := nftables.NewMonitor()
 	defer mon.Close()
-	events, err := conn.AddMonitor(mon)
+	events, err := conn.AddGenerationalMonitor(mon)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestMonitor(t *testing.T) {
 
 	// default to monitor all
 	monitor := nftables.NewMonitor()
-	events, err := c.AddMonitor(monitor)
+	events, err := c.AddGenerationalMonitor(monitor)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/set.go
+++ b/set.go
@@ -268,12 +268,6 @@ type Set struct {
 	KeyByteOrder binaryutil.ByteOrder
 }
 
-type SetElementsInfo struct {
-	TableName string
-	SetName   string
-	Elements  []SetElement
-}
-
 // SetElement represents a data point within a set.
 type SetElement struct {
 	Key []byte
@@ -803,15 +797,10 @@ func elementsFromMsg(fam byte, msg netlink.Message) ([]SetElement, error) {
 	}
 	ad.ByteOrder = binary.BigEndian
 
-	var info = &SetElementsInfo{}
 	var elements []SetElement
 	for ad.Next() {
 		b := ad.Bytes()
 		switch ad.Type() {
-		case unix.NFTA_SET_ELEM_LIST_TABLE:
-			info.TableName = ad.String()
-		case unix.NFTA_SET_ELEM_LIST_SET:
-			info.SetName = ad.String()
 		case unix.NFTA_SET_ELEM_LIST_ELEMENTS:
 			ad, err := netlink.NewAttributeDecoder(b)
 			if err != nil {
@@ -829,6 +818,7 @@ func elementsFromMsg(fam byte, msg netlink.Message) ([]SetElement, error) {
 			}
 		}
 	}
+
 	return elements, nil
 }
 

--- a/set.go
+++ b/set.go
@@ -800,8 +800,7 @@ func elementsFromMsg(fam byte, msg netlink.Message) ([]SetElement, error) {
 	var elements []SetElement
 	for ad.Next() {
 		b := ad.Bytes()
-		switch ad.Type() {
-		case unix.NFTA_SET_ELEM_LIST_ELEMENTS:
+		if ad.Type() == unix.NFTA_SET_ELEM_LIST_ELEMENTS {
 			ad, err := netlink.NewAttributeDecoder(b)
 			if err != nil {
 				return nil, err
@@ -818,7 +817,6 @@ func elementsFromMsg(fam byte, msg netlink.Message) ([]SetElement, error) {
 			}
 		}
 	}
-
 	return elements, nil
 }
 

--- a/set.go
+++ b/set.go
@@ -268,6 +268,12 @@ type Set struct {
 	KeyByteOrder binaryutil.ByteOrder
 }
 
+type SetElementsInfo struct {
+	TableName string
+	SetName   string
+	Elements  []SetElement
+}
+
 // SetElement represents a data point within a set.
 type SetElement struct {
 	Key []byte
@@ -797,10 +803,16 @@ func elementsFromMsg(fam byte, msg netlink.Message) ([]SetElement, error) {
 	}
 	ad.ByteOrder = binary.BigEndian
 
+	var info = &SetElementsInfo{}
 	var elements []SetElement
 	for ad.Next() {
 		b := ad.Bytes()
-		if ad.Type() == unix.NFTA_SET_ELEM_LIST_ELEMENTS {
+		switch ad.Type() {
+		case unix.NFTA_SET_ELEM_LIST_TABLE:
+			info.TableName = ad.String()
+		case unix.NFTA_SET_ELEM_LIST_SET:
+			info.SetName = ad.String()
+		case unix.NFTA_SET_ELEM_LIST_ELEMENTS:
 			ad, err := netlink.NewAttributeDecoder(b)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Hi!

While using nftables, we discovered it would be more efficient to process monitor events (changes) all at once upon commit, triggered by the event that caused the change, such as [NFT_MSG_NEWGEN](https://elixir.bootlin.com/linux/v6.10.10/source/net/netfilter/nf_tables_api.c#L10514).

This PR modifies the way events are handled by grouping all changes together and processing them in response to the event that initiated the change. Additionally, the event header, which includes important information such as the PID, is now propagated. This allows us to identify the process responsible for the change.