### PR TITLE
Fix incorrect size check in NFGenMsg

### DIFF
--- a/monitor_test.go
+++ b/monitor_test.go
@@ -156,6 +156,9 @@ func TestMonitor(t *testing.T) {
 		*gotChain.Hooknum != *postrouting.Hooknum {
 		t.Fatal("no want chain", gotChain.Type, gotChain.Name, gotChain.Hooknum)
 	}
+	if gotRule.Table.Family != nat.Family {
+		t.Fatal("rule wrong family", gotRule.Table.Family, gotRule.Table.Name)
+	}
 	if len(gotRule.Exprs) != len(rule.Exprs) {
 		t.Fatal("no want rule")
 	}

--- a/util.go
+++ b/util.go
@@ -38,7 +38,7 @@ type NFGenMsg struct {
 }
 
 func (genmsg *NFGenMsg) Decode(b []byte) {
-	if len(b) < 16 {
+	if len(b) < 4 {
 		return
 	}
 	genmsg.NFGenFamily = b[0]


### PR DESCRIPTION
This patch resolves an issue with the size check in `NFGenMsg`.

Currently, the size is truncated to 4 bytes, but the check incorrectly expects 16 bytes. As a result, `NFGenMsg.Decode` is never executed.

You can find the relevant code here:
https://github.com/google/nftables/blob/51c44dcf0573a890bb26fc621fa0142e16b94261/monitor.go#L375

This fix ensures that NFGenMsg is decoded correctly.