### PR TITLE
set: Add set support for size specifier, add missing dynamic flag unmarshal

### DIFF
--- a/set.go
+++ b/set.go
@@ -267,6 +267,8 @@ type Set struct {
 	// https://git.netfilter.org/nftables/tree/include/datatype.h?id=d486c9e626405e829221b82d7355558005b26d8a#n109
 	KeyByteOrder binaryutil.ByteOrder
 	Comment      string
+	// Indicates that the set has "size" specifier
+	Size uint32
 }
 
 // SetElement represents a data point within a set.
@@ -553,6 +555,21 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 		}
 		tableInfo = append(tableInfo, netlink.Attribute{Type: unix.NLA_F_NESTED | unix.NFTA_SET_DESC, Data: numberOfElements})
 	}
+
+	var descBytes []byte
+
+	if s.Size > 0 {
+		// Marshal set size description
+		descSizeBytes, err := netlink.MarshalAttributes([]netlink.Attribute{
+			{Type: unix.NFTA_SET_DESC_SIZE, Data: binaryutil.BigEndian.PutUint32(s.Size)},
+		})
+		if err != nil {
+			return fmt.Errorf("fail to marshal set size description: %w", err)
+		}
+
+		descBytes = append(descBytes, descSizeBytes...)
+	}
+
 	if s.Concatenation {
 		// Length of concatenated types is a must, otherwise segfaults when executing nft list ruleset
 		var concatDefinition []byte
@@ -579,8 +596,13 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 		if err != nil {
 			return fmt.Errorf("fail to marshal concat definition %v", err)
 		}
-		// Marshal concat size description as set description
-		tableInfo = append(tableInfo, netlink.Attribute{Type: unix.NLA_F_NESTED | unix.NFTA_SET_DESC, Data: concatBytes})
+
+		descBytes = append(descBytes, concatBytes...)
+	}
+
+	if len(descBytes) > 0 {
+		// Marshal set description
+		tableInfo = append(tableInfo, netlink.Attribute{Type: unix.NLA_F_NESTED | unix.NFTA_SET_DESC, Data: descBytes})
 	}
 
 	// https://git.netfilter.org/libnftnl/tree/include/udata.h#n17
@@ -763,6 +785,20 @@ func setsFromMsg(msg netlink.Message) (*Set, error) {
 			data := ad.Bytes()
 			value, ok := userdata.GetUint32(data, userdata.NFTNL_UDATA_SET_MERGE_ELEMENTS)
 			set.AutoMerge = ok && value == 1
+		case unix.NFTA_SET_DESC:
+			nestedAD, err := netlink.NewAttributeDecoder(ad.Bytes())
+			if err != nil {
+				return nil, fmt.Errorf("nested NewAttributeDecoder() failed: %w", err)
+			}
+			for nestedAD.Next() {
+				switch nestedAD.Type() {
+				case unix.NFTA_SET_DESC_SIZE:
+					set.Size = binary.BigEndian.Uint32(nestedAD.Bytes())
+				}
+			}
+			if nestedAD.Err() != nil {
+				return nil, fmt.Errorf("decoding set description: %w", nestedAD.Err())
+			}
 		}
 	}
 	return &set, nil

--- a/set.go
+++ b/set.go
@@ -734,6 +734,7 @@ func setsFromMsg(msg netlink.Message) (*Set, error) {
 			set.Interval = (flags & unix.NFT_SET_INTERVAL) != 0
 			set.IsMap = (flags & unix.NFT_SET_MAP) != 0
 			set.HasTimeout = (flags & unix.NFT_SET_TIMEOUT) != 0
+			set.Dynamic = (flags & unix.NFT_SET_EVAL) != 0
 			set.Concatenation = (flags & NFT_SET_CONCAT) != 0
 		case unix.NFTA_SET_KEY_TYPE:
 			nftMagic := ad.Uint32()


### PR DESCRIPTION
Add support for set size specification: handle attribute `NFTNL_SET_DESC_SIZE`, as done in `libnftnl`: https://git.netfilter.org/libnftnl/tree/src/set.c#n424

Example:
```sh
nft add set ip filter myset { type ipv4_addr\; size 65535\; flags dynamic\; }
```

Also add missing unmarshal of `Dynamic` flag (`NFT_SET_EVAL`).