### PR TITLE
Fix Fib parsing

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -207,6 +207,8 @@ func exprFromName(name string) Any {
 		e = &SecMark{}
 	case "cttimeout":
 		e = &CtTimeout{}
+	case "fib":
+		e = &Fib{}
 	}
 	return e
 }

--- a/expr/fib.go
+++ b/expr/fib.go
@@ -118,17 +118,22 @@ func (e *Fib) unmarshal(fam byte, data []byte) error {
 			e.Register = ad.Uint32()
 		case unix.NFTA_FIB_RESULT:
 			result := ad.Uint32()
-			e.ResultOIF = (result & unix.NFT_FIB_RESULT_OIF) == 1
-			e.ResultOIFNAME = (result & unix.NFT_FIB_RESULT_OIFNAME) == 1
-			e.ResultADDRTYPE = (result & unix.NFT_FIB_RESULT_ADDRTYPE) == 1
+			switch result {
+			case unix.NFT_FIB_RESULT_OIF:
+				e.ResultOIF = true
+			case unix.NFT_FIB_RESULT_OIFNAME:
+				e.ResultOIFNAME = true
+			case unix.NFT_FIB_RESULT_ADDRTYPE:
+				e.ResultADDRTYPE = true
+			}
 		case unix.NFTA_FIB_FLAGS:
 			flags := ad.Uint32()
-			e.FlagSADDR = (flags & unix.NFTA_FIB_F_SADDR) == 1
-			e.FlagDADDR = (flags & unix.NFTA_FIB_F_DADDR) == 1
-			e.FlagMARK = (flags & unix.NFTA_FIB_F_MARK) == 1
-			e.FlagIIF = (flags & unix.NFTA_FIB_F_IIF) == 1
-			e.FlagOIF = (flags & unix.NFTA_FIB_F_OIF) == 1
-			e.FlagPRESENT = (flags & unix.NFTA_FIB_F_PRESENT) == 1
+			e.FlagSADDR = (flags & unix.NFTA_FIB_F_SADDR) != 0
+			e.FlagDADDR = (flags & unix.NFTA_FIB_F_DADDR) != 0
+			e.FlagMARK = (flags & unix.NFTA_FIB_F_MARK) != 0
+			e.FlagIIF = (flags & unix.NFTA_FIB_F_IIF) != 0
+			e.FlagOIF = (flags & unix.NFTA_FIB_F_OIF) != 0
+			e.FlagPRESENT = (flags & unix.NFTA_FIB_F_PRESENT) != 0
 		}
 	}
 	return ad.Err()

--- a/expr/limit.go
+++ b/expr/limit.go
@@ -123,7 +123,7 @@ func (l *Limit) unmarshal(fam byte, data []byte) error {
 				return fmt.Errorf("expr: invalid limit type %d", l.Type)
 			}
 		case unix.NFTA_LIMIT_FLAGS:
-			l.Over = (ad.Uint32() & unix.NFT_LIMIT_F_INV) == 1
+			l.Over = (ad.Uint32() & unix.NFT_LIMIT_F_INV) != 0
 		default:
 			return errors.New("expr: unhandled limit netlink attribute")
 		}

--- a/expr/quota.go
+++ b/expr/quota.go
@@ -73,7 +73,7 @@ func (q *Quota) unmarshal(fam byte, data []byte) error {
 		case unix.NFTA_QUOTA_CONSUMED:
 			q.Consumed = ad.Uint64()
 		case unix.NFTA_QUOTA_FLAGS:
-			q.Over = (ad.Uint32() & unix.NFT_QUOTA_F_INV) == 1
+			q.Over = (ad.Uint32() & unix.NFT_QUOTA_F_INV) != 0
 		}
 	}
 	return ad.Err()

--- a/quota.go
+++ b/quota.go
@@ -36,7 +36,7 @@ func (q *QuotaObj) unmarshal(ad *netlink.AttributeDecoder) error {
 		case unix.NFTA_QUOTA_CONSUMED:
 			q.Consumed = ad.Uint64()
 		case unix.NFTA_QUOTA_FLAGS:
-			q.Over = (ad.Uint32() & unix.NFT_QUOTA_F_INV) == 1
+			q.Over = (ad.Uint32() & unix.NFT_QUOTA_F_INV) != 0
 		}
 	}
 	return nil


### PR DESCRIPTION
Per issue #291, FIB objects are not parsed although the implementation exists. This PR fixes this issue.

Additionally, the initial FIB implementation did not parse the object properly so I changed that as well. The initial implementation assumed that result field is uint32 used as flag, but per original libnftnl implementation, I would say that result is uint32 referring to only a single value: https://git.netfilter.org/libnftnl/tree/include/linux/netfilter/nf_tables.h?id=ff37c01480cd0b938658d180ff5c7b1958ad250f#n1605

Since the initial implementation used booleans, I decided to not change that for this PR.