### PR TITLE
Fixed the bug of missing expression numgen from GetRules

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -209,6 +209,8 @@ func exprFromName(name string) Any {
 		e = &CtTimeout{}
 	case "fib":
 		e = &Fib{}
+	case "numgen":
+		e = &Numgen{}
 	}
 	return e
 }


### PR DESCRIPTION
When we create a rule with expression numgen, it is created correctly. Here's an example:
```
table inet james-filter {
	map m2798997459 {
		type 0 : ipv4_addr
		flags constant
		elements = { 0 : 1.1.1.1, 1 : 2.2.2.2, 2 : 3.3.3.3 }
	}
	chain input {
		type nat hook prerouting priority filter; policy accept;
		ip saddr 1.1.1.1 th dport 2222 log prefix "nflog" group 0 counter packets 0 bytes 0 dnat ip to numgen inc mod 3 map @m2798997459 comment "temp rule"
	}
}
```

However, when we get the same rule from netlink via this library, the expression numgen is missing:
```
2025/01/31 20:52:41 *expr.Meta &{15 false 1}
2025/01/31 20:52:41 *expr.Cmp &{0 1 [2]}
2025/01/31 20:52:41 *expr.Payload &{0 1 0 1 12 4 0 0 0}
2025/01/31 20:52:41 *expr.Cmp &{0 1 [1 1 1 1]}
2025/01/31 20:52:41 *expr.Payload &{0 1 0 2 2 2 0 0 0}
2025/01/31 20:52:41 *expr.Cmp &{0 1 [8 174]}
2025/01/31 20:52:41 *expr.Log &{0 0 6 0 0 0 [110 102 108 111 103]}
2025/01/31 20:52:41 *expr.Counter &{0 0}
2025/01/31 20:52:41 *expr.Lookup &{1 1 true 0 m2798997459 false}
2025/01/31 20:52:41 *expr.NAT &{1 2 1 1 0 0 false false false false false}
```

Example with fix:
```
2025/01/31 20:52:14 *expr.Meta &{15 false 1}
2025/01/31 20:52:14 *expr.Cmp &{0 1 [2]}
2025/01/31 20:52:14 *expr.Payload &{0 1 0 1 12 4 0 0 0}
2025/01/31 20:52:14 *expr.Cmp &{0 1 [1 1 1 1]}
2025/01/31 20:52:14 *expr.Payload &{0 1 0 2 2 2 0 0 0}
2025/01/31 20:52:14 *expr.Cmp &{0 1 [8 174]}
2025/01/31 20:52:14 *expr.Log &{0 0 6 0 0 0 [110 102 108 111 103]}
2025/01/31 20:52:14 *expr.Counter &{0 0}
2025/01/31 20:52:14 *expr.Numgen &{1 3 0 0}
2025/01/31 20:52:14 *expr.Lookup &{1 1 true 0 m2798997459 false}
2025/01/31 20:52:14 *expr.NAT &{1 2 1 1 0 0 false false false false false}
```