### PR TITLE
Initialize registers in test

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -3,6 +3,7 @@ package nftables
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/mdlayher/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -13,7 +14,7 @@ type GenMsg struct {
 	ProcComm string // [16]byte - max 16bytes - kernel TASK_COMM_LEN
 }
 
-var genHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWGEN)
+const genHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWGEN)
 
 func genFromMsg(msg netlink.Message) (*GenMsg, error) {
 	if got, want := msg.Header.Type, genHeaderType; got != want {

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -622,6 +622,14 @@ func TestMasqMarshalUnmarshal(t *testing.T) {
 		Table: filter,
 		Chain: postrouting,
 		Exprs: []expr.Any{
+			&expr.Immediate{
+				Register: min,
+				Data:     binaryutil.BigEndian.PutUint16(4070),
+			},
+			&expr.Immediate{
+				Register: max,
+				Data:     binaryutil.BigEndian.PutUint16(4090),
+			},
 			&expr.Masq{
 				ToPorts:     true,
 				RegProtoMin: min,
@@ -652,13 +660,13 @@ func TestMasqMarshalUnmarshal(t *testing.T) {
 	}
 
 	rule := rules[0]
-	if got, want := len(rule.Exprs), 1; got != want {
+	if got, want := len(rule.Exprs), 3; got != want {
 		t.Fatalf("unexpected number of exprs: got %d, want %d", got, want)
 	}
 
-	me, ok := rule.Exprs[0].(*expr.Masq)
+	me, ok := rule.Exprs[2].(*expr.Masq)
 	if !ok {
-		t.Fatalf("unexpected expression type: got %T, want *expr.Masq", rule.Exprs[0])
+		t.Fatalf("unexpected expression type: got %T, want *expr.Masq", rule.Exprs[2])
 	}
 
 	if got, want := me.ToPorts, true; got != want {

--- a/obj.go
+++ b/obj.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var (
+const (
 	newObjHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWOBJ)
 	delObjHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELOBJ)
 )

--- a/rule.go
+++ b/rule.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var (
+const (
 	newRuleHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWRULE)
 	delRuleHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE)
 )

--- a/set.go
+++ b/set.go
@@ -166,7 +166,9 @@ var (
 		TypeTimeDay,
 		TypeCGroupV2,
 	}
+)
 
+const (
 	// ctLabelBitSize is defined in https://git.netfilter.org/nftables/tree/src/ct.c.
 	ctLabelBitSize uint32 = 128
 
@@ -737,7 +739,7 @@ func (cc *Conn) FlushSet(s *Set) {
 	})
 }
 
-var (
+const (
 	newSetHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWSET)
 	delSetHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSET)
 )
@@ -837,7 +839,7 @@ func parseSetDatatype(magic uint32) (SetDatatype, error) {
 	return dt, nil
 }
 
-var (
+const (
 	newElemHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWSETELEM)
 	delElemHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELSETELEM)
 )

--- a/table.go
+++ b/table.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var (
+const (
 	newTableHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWTABLE)
 	delTableHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELTABLE)
 )


### PR DESCRIPTION
Recent kernels disallow reads from uninitialized registers, which breaks this test.

See https://github.com/torvalds/linux/commit/14fb07130c7ddd257e30079b87499b3f89097b09

Additionally, I changed some global variables which did not need to be variable into constants.