### PR TITLE
Deprecate Rule.Flags field

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -62,10 +62,8 @@ type Rule struct {
 	// PositionID can be set to the ID of another Rule, same as Position, for when
 	// the existing rule is not yet committed.
 	PositionID uint32
-	// The list of possible flags are specified by nftnl_rule_attr, see
-	// https://git.netfilter.org/libnftnl/tree/include/libnftnl/rule.h#n21
-	// Current nftables go implementation supports only
-	// NFTNL_RULE_POSITION flag for setting rule at position 0
+	// Deprecated: The feature for which this field was added never worked.
+	// The field may be removed in a later version.
 	Flags    uint32
 	Exprs    []expr.Any
 	UserData []byte
@@ -186,7 +184,7 @@ func (cc *Conn) newRule(r *Rule, op ruleOperation) *Rule {
 		flags = netlink.Request | netlink.Acknowledge | netlink.Replace
 	}
 
-	if r.Position != 0 || (r.Flags&(1<<unix.NFTA_RULE_POSITION)) != 0 {
+	if r.Position != 0 {
 		msgData = append(msgData, cc.marshalAttr([]netlink.Attribute{
 			{Type: unix.NFTA_RULE_POSITION, Data: binaryutil.BigEndian.PutUint64(r.Position)},
 		})...)


### PR DESCRIPTION
The functionality added in a46119e5 never worked: If you set NFTA_RULE_POSITION to 0, the kernel will just complain that a rule with this handle does not exist. This removes the broken functionality, leaving the field deprecated.

The right way to insert a rule at the beginning of a chain is to use InsertRule and leave Position unset.

https://github.com/google/nftables/issues/126 mentions that the nft command allows referring to rules by index. But here is a quote from the nft manpage:

> The add and insert commands support an optional location specifier,
> which is either a handle or the index (starting at zero) of an
> existing rule. Internally, rule locations are always identified by
> handle and the translation from index happens in userspace.

In other words, identifiying rules by index is a feature of nft and is not part of the kernel interface.