### PR TITLE
Improve safety of ID allocation

### DIFF
--- a/set.go
+++ b/set.go
@@ -46,8 +46,6 @@ const (
 	NFTA_SET_ELEM_EXPRESSIONS = 0x11
 )
 
-var allocSetID uint32
-
 // SetDatatype represents a datatype declared by nft.
 type SetDatatype struct {
 	Name  string
@@ -532,8 +530,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	}
 
 	if s.ID == 0 {
-		allocSetID++
-		s.ID = allocSetID
+		s.ID = cc.allocateTransactionID()
 		if s.Anonymous {
 			s.Name = "__set%d"
 			if s.IsMap {


### PR DESCRIPTION
There was an existing mechanism to allocate IDs for sets, but this was using a global counter without any synchronization to prevent data races. I replaced this by a new mechanism which uses a connection-scoped counter, protected by the Conn.mu Mutex. This can then also be used in other places where IDs need to be allocated.

As an additional safeguard, it will panic instead of allocating the same ID twice in a transaction. Most likely, your program will run out of memory before reaching this point.