### PR TITLE
Automatically set socket read & write buffer sizes

### DIFF
--- a/nftables_test.go
+++ b/nftables_test.go
@@ -7396,3 +7396,37 @@ func TestSetElementComment(t *testing.T) {
 		}
 	}
 }
+
+func TestAutoBufferSize(t *testing.T) {
+	conn, newNS := nftest.OpenSystemConn(t, *enableSysTests)
+	defer nftest.CleanupSystemConn(t, newNS)
+	conn.FlushRuleset()
+	defer conn.FlushRuleset()
+
+	table := conn.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyIPv4,
+		Name:   "test-table",
+	})
+
+	chain := conn.AddChain(&nftables.Chain{
+		Name:  "test-chain",
+		Table: table,
+	})
+
+	for i := 0; i < 4096; i++ {
+		conn.AddRule(&nftables.Rule{
+			Table: table,
+			Chain: chain,
+			Exprs: []expr.Any{
+				&expr.Verdict{
+					Kind: expr.VerdictAccept,
+				},
+			},
+		})
+	}
+
+	err := conn.Flush()
+	if err != nil {
+		t.Fatalf("failed to flush: %v", err)
+	}
+}


### PR DESCRIPTION
This is an attempt to port some of the logic that nftables uses to automatically adjust the recvmsg & sndmsg buffer sizes. The implementation of setting sndmsg size is not the same as nftables due to some limitations in the underlying netlink & socket libraries.

You can compare it the behavior to nftables if you:
  - `strace -e trace=sendmsg,setsockopt,getsockopt -s 16384 -xx  ./nftables.test -test.v -run_system_tests -test.run ^TestAutoBufferSize$`
  - `strace -e trace=sendmsg,setsockopt,getsockopt -s 16384 -xx nft --echo -f ./test-rules` where `test-rules` contains https://gist.github.com/nickgarlis/d31cf585b77eef0628118704db8e8310
  
 In my system it's 
```
getsockopt(7, SOL_SOCKET, SO_SNDBUF, [212992], [4]) = 0
setsockopt(7, SOL_SOCKET, SO_SNDBUFFORCE, [458868], 4) = 0
getsockopt(7, SOL_SOCKET, SO_RCVBUF, [212992], [4]) = 0
setsockopt(7, SOL_SOCKET, SO_RCVBUFFORCE, [4197376], 4) = 0 
```
and 
```
getsockopt(3, SOL_SOCKET, SO_SNDBUF, [212992], [4]) = 0
setsockopt(3, SOL_SOCKET, SO_SNDBUF, [2097152], 4) = 0
setsockopt(3, SOL_SOCKET, SO_SNDBUFFORCE, [2097152], 4) = 0
getsockopt(3, SOL_SOCKET, SO_RCVBUF, [212992], [4]) = 0
setsockopt(3, SOL_SOCKET, SO_RCVBUFFORCE, [4197376], 4) = 0
```
respectively.


The change depends on https://github.com/mdlayher/netlink/pull/223

- https://git.netfilter.org/nftables/tree/src/mnl.c?id=713592c6008a8c589a00d3d3d2e49709ff2de62c#n262
- https://git.netfilter.org/libmnl/tree/include/libmnl/libmnl.h?id=03da98bcd284d55212bc79e91dfb63da0ef7b937#n20
- https://git.netfilter.org/nftables/tree/src/mnl.c?id=713592c6008a8c589a00d3d3d2e49709ff2de62c#n391
- https://git.netfilter.org/nftables/tree/src/mnl.c?id=713592c6008a8c589a00d3d3d2e49709ff2de62c#n426