### PR TITLE
Add optional direction field

### DIFF
--- a/expr/ct_test.go
+++ b/expr/ct_test.go
@@ -78,6 +78,22 @@ func TestCt(t *testing.T) {
 				Direction: 1,
 			},
 		},
+		{
+			name: "Unmarshal Ct packets direction original case",
+			ct: Ct{
+				Register:     1,
+				Key:          CtKeyPKTS,
+				Direction:    CtDirOriginal,
+				OptDirection: true,
+			},
+		},
+		{
+			name: "Unmarshal Ct bytes without direction case",
+			ct: Ct{
+				Register: 1,
+				Key:      CtKeyBYTES,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Add optional direction field to connection tracking expressions

This pull request adds support for an optional direction field in ct expressions. The direction field specifies whether the connection tracking information should be retrieved from the original or reply direction of the connection.

## Changes

- Added constants `CtDirOriginal` and `CtDirReply` to represent the possible direction values
- Added a new `OptDirection` boolean field to the `Ct` struct to indicate whether the direction field should be included for certain connection tracking keys
- Modified the marshaling logic to conditionally include the direction field based on the `OptDirection` flag for the following keys ([source](https://wiki.nftables.org/wiki-nftables/index.php/Matching_connection_tracking_stateful_metainformation#ct_packets)):
  - `CtKeyPKTS`
  - `CtKeyBYTES`
  - `CtKeyAVGPKT`
  - `CtKeyL3PROTOCOL`
  - `CtKeyPROTOCOL`
- Fixed the data type for the direction field in marshaling (changed from uint32 to uint8)
- Added logic in the unmarshaling process to detect if a direction was present and set the `OptDirection` flag accordingly
- Added test cases to verify the new functionality

## Motivation

In nftables, certain connection tracking keys like packets and bytes counters can optionally specify a direction. This allows users to retrieve statistics for either the original or reply direction of a connection. Previously, the library didn't support specifying a direction for these keys, limiting the flexibility of connection tracking expressions.

## Backward Compatibility

This change is fully backward compatible:
- Existing code that doesn't use the direction field for these keys will continue to work as before
- The `OptDirection` field defaults to false, maintaining the previous behavior
- The unmarshaling process correctly handles both cases (with and without direction)

## Example Usage

```go
// Create a ct expression to get packet count from the original direction
ct := &expr.Ct{
    Register:     1,
    Key:          expr.CtKeyPKTS,
    Direction:    expr.CtDirOriginal,
    OptDirection: true,
}

// Create a ct expression to get packet count without specifying direction
ct := &expr.Ct{
    Register: 1,
    Key:      expr.CtKeyPKTS,
}
```