### PR TITLE
add DataInterval flag for maps, fix comments

### DIFF
--- a/set_test.go
+++ b/set_test.go
@@ -257,11 +257,24 @@ func TestMarshalSet(t *testing.T) {
 			name: "Vedict map",
 			set: Set{
 				Name:     "test-map",
-				ID:       uint32(3),
+				ID:       uint32(4),
 				Table:    tbl,
 				KeyType:  TypeIPAddr,
 				DataType: TypeVerdict,
 				IsMap:    true,
+			},
+		},
+		{
+			name: "Map ip-ip", // generic case
+			set: Set{
+				Name:         "test-map",
+				ID:           uint32(5),
+				Table:        tbl,
+				KeyType:      TypeIPAddr,
+				DataType:     TypeIPAddr,
+				DataInterval: true,
+				IsMap:        true,
+				Comment:      "test-comment",
 			},
 		},
 	}


### PR DESCRIPTION
It is impossible to create map like this `nft add map ip SFW_NAT mmap { type ipv4_addr : interval ipv4_addr ; }`  without flag `NFTNL_UDATA_SET_DATA_INTERVAL` in `userdata`. It needs for NAT. Now we support it. Also fix comments for sets (was ignored on parsing from netlink).