### PR TITLE
Accumulate errors until Flush to avoid incomplete batches

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -42,7 +42,7 @@ type Conn struct {
 	lasting      bool       // establish a lasting connection to be used across multiple netlink operations.
 	mu           sync.Mutex // protects the following state
 	messages     []netlinkMessage
-	err          error
+	errs         []error
 	nlconn       *netlink.Conn // netlink socket using NETLINK_NETFILTER protocol.
 	sockOptions  []SockOption
 	lastID       uint32
@@ -250,14 +250,15 @@ func (cc *Conn) flush(genID uint32) error {
 	defer func() {
 		cc.messages = nil
 		cc.allocatedIDs = 0
+		cc.errs = nil
 		cc.mu.Unlock()
 	}()
 	if len(cc.messages) == 0 {
 		// Messages were already programmed, returning nil
 		return nil
 	}
-	if cc.err != nil {
-		return cc.err // serialization error
+	if len(cc.errs) > 0 {
+		return errors.Join(cc.errs...)
 	}
 	conn, closer, err := cc.netlinkConnUnderLock()
 	if err != nil {
@@ -381,17 +382,17 @@ func (cc *Conn) dialNetlink() (*netlink.Conn, error) {
 	return conn, nil
 }
 
-func (cc *Conn) setErr(err error) {
-	if cc.err != nil {
+func (cc *Conn) appendErr(err error) {
+	if err == nil {
 		return
 	}
-	cc.err = err
+	cc.errs = append(cc.errs, err)
 }
 
 func (cc *Conn) marshalAttr(attrs []netlink.Attribute) []byte {
 	b, err := netlink.MarshalAttributes(attrs)
 	if err != nil {
-		cc.setErr(err)
+		cc.appendErr(err)
 		return nil
 	}
 	return b
@@ -400,7 +401,7 @@ func (cc *Conn) marshalAttr(attrs []netlink.Attribute) []byte {
 func (cc *Conn) marshalExpr(fam byte, e expr.Any) []byte {
 	b, err := expr.Marshal(fam, e)
 	if err != nil {
-		cc.setErr(err)
+		cc.appendErr(err)
 		return nil
 	}
 	return b

--- a/obj.go
+++ b/obj.go
@@ -111,7 +111,7 @@ func (cc *Conn) AddObj(o Obj) Obj {
 	defer cc.mu.Unlock()
 	data, err := expr.MarshalExprData(byte(o.family()), o.data())
 	if err != nil {
-		cc.setErr(err)
+		cc.appendErr(err)
 		return nil
 	}
 

--- a/rule.go
+++ b/rule.go
@@ -219,7 +219,7 @@ func (cc *Conn) newRule(r *Rule, op ruleOperation) *Rule {
 	})...)
 
 	if compatPolicy, err := getCompatPolicy(r.Exprs); err != nil {
-		cc.setErr(err)
+		cc.appendErr(err)
 	} else if compatPolicy != nil {
 		data = append(data, cc.marshalAttr([]netlink.Attribute{
 			{Type: unix.NLA_F_NESTED | unix.NFTA_RULE_COMPAT, Data: cc.marshalAttr([]netlink.Attribute{
@@ -339,7 +339,9 @@ func (cc *Conn) DelRule(r *Rule) error {
 			{Type: unix.NFTA_RULE_ID, Data: binaryutil.BigEndian.PutUint32(r.ID)},
 		})...)
 	} else {
-		return fmt.Errorf("rule must have a handle or ID")
+		err := fmt.Errorf("rule must have a handle or ID")
+		cc.appendErr(err)
+		return err
 	}
 	flags := netlink.Request | netlink.Acknowledge
 


### PR DESCRIPTION
Any create/update/delete (batched) operation that returns a validation or marshalling error could leave the message batch in an incomplete state due to short-circuiting. This leads to two issues:

  - Non-atomic transactions if Flush is called (incomplete batch)
  - No way for users to clear the incomplete batch without sending it to the kernel

With this change, errors are accumulated and returned during Flush as well.

See: https://github.com/google/nftables/issues/323