### PR TITLE
Ensure socket buffer draining during Flush

### DIFF
--- a/internal/nftest/util.go
+++ b/internal/nftest/util.go
@@ -1,0 +1,38 @@
+package nftest
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// AsUnprivileged temporarily drops the effective UID to an unprivileged
+// value (65535) while executing the provided function. It requires the
+// process to be running as root to be able to regain privileges afterwards.
+func AsUnprivileged(fn func() error) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	targetUID := math.MaxUint16
+	_, euid, suid := unix.Getresuid()
+
+	if euid != 0 && suid != 0 {
+		return fmt.Errorf("must be run as root to regain privileges (euid=%d suid=%d)", euid, suid)
+	}
+
+	// Drop privileges by changing only the effective UID
+	if err := unix.Setresuid(-1, targetUID, -1); err != nil {
+		return fmt.Errorf("failed to drop effective UID to %d: %w", targetUID, err)
+	}
+
+	// Restore when done
+	defer func() {
+		if err := unix.Setresuid(-1, euid, -1); err != nil {
+			panic(fmt.Sprintf("failed to restore euid=%d: %v", euid, err))
+		}
+	}()
+
+	return fn()
+}

--- a/socket.go
+++ b/socket.go
@@ -1,0 +1,39 @@
+package nftables
+
+import (
+	"fmt"
+
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// isReadReady reports whether the netlink connection is ready for reading.
+// It uses pselect6 with a zero timeout on the underlying raw connection.
+// This allows for an efficient check of socket readiness without blocking.
+// If the Conn was created with a TestDial function, it assumes readiness.
+func (cc *Conn) isReadReady(conn *netlink.Conn) (bool, error) {
+	if cc.TestDial != nil {
+		return true, nil
+	}
+
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return false, fmt.Errorf("get raw conn: %w", err)
+	}
+
+	var n int
+	var opErr error
+	err = rawConn.Control(func(fd uintptr) {
+		var readfds unix.FdSet
+		readfds.Zero()
+		readfds.Set(int(fd))
+
+		ts := &unix.Timespec{} // zero timeout: immediate return
+		n, opErr = unix.Pselect(int(fd)+1, &readfds, nil, nil, ts, nil)
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return n > 0, opErr
+}


### PR DESCRIPTION
This commit re-implements response handling for batch messages. The current implementation uses heuristics to drain the socket buffer by counting sent messages and making a blocking recvmsg call for each one. While this generally works, it has several problems:

  - No kernel guarantees: The kernel makes no guarantee about the number of ACKs returned. Error conditions like EPERM, ENOBUFS, and ENOMEM can cause unexpected behavior.
  - Vulnerable to kernel bugs: As described in https://github.com/google/nftables/issues/329
  - Complex code: ACK counting complicates the response handling logic in Flush

The new approach follows nft's pattern by leveraging netlink's synchronous request-response behavior. When a blocking sendmsg completes, the kernel has already processed the request and queued any response data in the socket's receive buffer. This means we can simply check if data is available rather than blocking indefinitely waiting for a specific number of responses.

The implementation uses pselect6 (the same syscall nft uses) to poll the socket for readability. Other polling syscalls would work too, but in my opinion epoll would be an overkill here. While Go's network poller does use epoll, it does so for async I/O scenarios where it persistently monitors many file descriptors. Our use case is different: we're doing synchronous I/O and only need a one-shot check of a single socket with an immediate result.