### PR TITLE
support to parse Socket type expr

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -211,6 +211,8 @@ func exprFromName(name string) Any {
 		e = &Fib{}
 	case "numgen":
 		e = &Numgen{}
+	case "socket":
+		e = &Socket{}
 	}
 	return e
 }


### PR DESCRIPTION
conn.GetRules fail to return Socket expr. The testing nft rule is as below:

chain test {
    socket transparent 1 meta mark set meta mark | 0x00000080 return
}