### PR TITLE
Refactor receive logic to reuse message reading sequence

### DIFF
--- a/flowtable.go
+++ b/flowtable.go
@@ -217,9 +217,9 @@ func (cc *Conn) getFlowtables(t *Table) ([]netlink.Message, error) {
 		return nil, fmt.Errorf("SendMessages: %v", err)
 	}
 
-	reply, err := receiveAckAware(conn, message.Header.Flags)
+	reply, err := cc.receive(conn)
 	if err != nil {
-		return nil, fmt.Errorf("receiveAckAware: %v", err)
+		return nil, fmt.Errorf("receive: %v", err)
 	}
 
 	return reply, nil

--- a/gen.go
+++ b/gen.go
@@ -77,12 +77,12 @@ func (cc *Conn) GetGen() (*Gen, error) {
 		return nil, fmt.Errorf("SendMessages: %v", err)
 	}
 
-	reply, err := receiveAckAware(conn, message.Header.Flags)
+	reply, err := cc.receive(conn)
 	if err != nil {
-		return nil, fmt.Errorf("receiveAckAware: %v", err)
+		return nil, fmt.Errorf("receive: %v", err)
 	}
 	if len(reply) == 0 {
-		return nil, fmt.Errorf("receiveAckAware: no reply")
+		return nil, fmt.Errorf("receive: no reply")
 	}
 	return genFromMsg(reply[0])
 }

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -1088,6 +1088,10 @@ func TestGetRules(t *testing.T) {
 				}
 				want = want[1:]
 			}
+
+			if len(reply) == 0 {
+				return nil, nil
+			}
 			rep := reply[0]
 			reply = reply[1:]
 			return rep, nil
@@ -2394,6 +2398,9 @@ func TestGetObjReset(t *testing.T) {
 					t.Errorf("message %d: %s", idx, linediff(nfdump(got), nfdump(want)))
 				}
 				want = want[1:]
+			}
+			if len(reply) == 0 {
+				return nil, nil
 			}
 			rep := reply[0]
 			reply = reply[1:]

--- a/obj.go
+++ b/obj.go
@@ -364,9 +364,9 @@ func (cc *Conn) getObjWithLegacyType(o Obj, t *Table, msgType uint16, returnLega
 		return nil, fmt.Errorf("SendMessages: %v", err)
 	}
 
-	reply, err := receiveAckAware(conn, message.Header.Flags)
+	reply, err := cc.receive(conn)
 	if err != nil {
-		return nil, fmt.Errorf("receiveAckAware: %v", err)
+		return nil, fmt.Errorf("receive: %v", err)
 	}
 	var objs []Obj
 	for _, msg := range reply {

--- a/rule.go
+++ b/rule.go
@@ -171,9 +171,9 @@ func (cc *Conn) getRules(t *Table, c *Chain, msgType int, handle uint64) ([]*Rul
 		return nil, fmt.Errorf("SendMessages: %v", err)
 	}
 
-	reply, err := receiveAckAware(conn, message.Header.Flags)
+	reply, err := cc.receive(conn)
 	if err != nil {
-		return nil, fmt.Errorf("receiveAckAware: %v", err)
+		return nil, fmt.Errorf("receive: %v", err)
 	}
 	var rules []*Rule
 	for _, msg := range reply {

--- a/set.go
+++ b/set.go
@@ -955,9 +955,9 @@ func (cc *Conn) GetSets(t *Table) ([]*Set, error) {
 		return nil, fmt.Errorf("SendMessages: %v", err)
 	}
 
-	reply, err := receiveAckAware(conn, message.Header.Flags)
+	reply, err := cc.receive(conn)
 	if err != nil {
-		return nil, fmt.Errorf("receiveAckAware: %v", err)
+		return nil, fmt.Errorf("receive: %v", err)
 	}
 	var sets []*Set
 	for _, msg := range reply {
@@ -1000,13 +1000,13 @@ func (cc *Conn) GetSetByName(t *Table, name string) (*Set, error) {
 		return nil, fmt.Errorf("SendMessages: %w", err)
 	}
 
-	reply, err := receiveAckAware(conn, message.Header.Flags)
+	reply, err := cc.receive(conn)
 	if err != nil {
-		return nil, fmt.Errorf("receiveAckAware: %w", err)
+		return nil, fmt.Errorf("receive: %w", err)
 	}
 
 	if len(reply) != 1 {
-		return nil, fmt.Errorf("receiveAckAware: expected to receive 1 message but got %d", len(reply))
+		return nil, fmt.Errorf("receive: expected to receive 1 message but got %d", len(reply))
 	}
 	rs, err := setsFromMsg(reply[0])
 	if err != nil {
@@ -1045,9 +1045,9 @@ func (cc *Conn) GetSetElements(s *Set) ([]SetElement, error) {
 		return nil, fmt.Errorf("SendMessages: %v", err)
 	}
 
-	reply, err := receiveAckAware(conn, message.Header.Flags)
+	reply, err := cc.receive(conn)
 	if err != nil {
-		return nil, fmt.Errorf("receiveAckAware: %v", err)
+		return nil, fmt.Errorf("receive: %v", err)
 	}
 	var elems []SetElement
 	for _, msg := range reply {


### PR DESCRIPTION
Introduce a `receiveSeq` iterator to simplify reading messages from the socket without copying them into a temporary slice. It yields only messages relevant to nftables operations (i.e., those containing nftables attributes).

Also refactor `receiveAckAware` into a reusable `receive` method, which, like `flush`, uses the same `receiveSeq` iterator for consistency.