### PR TITLE
Enhance error tracing

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -142,7 +142,7 @@ func (cc *Conn) AddChain(c *Chain) *Chain {
 	}
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWCHAIN),
+			Type:  nftMsgNewChain.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
 		},
 		Data: append(extraHeader(uint8(c.Table.Family), 0), data...),
@@ -163,7 +163,7 @@ func (cc *Conn) DelChain(c *Chain) {
 
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELCHAIN),
+			Type:  nftMsgDelChain.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge,
 		},
 		Data: append(extraHeader(uint8(c.Table.Family), 0), data...),
@@ -181,7 +181,7 @@ func (cc *Conn) FlushChain(c *Chain) {
 	})
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
+			Type:  nftMsgDelRule.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge,
 		},
 		Data: append(extraHeader(uint8(c.Table.Family), 0), data...),
@@ -207,7 +207,7 @@ func (cc *Conn) ListChain(table *Table, chain string) (*Chain, error) {
 	}
 	msg := netlink.Message{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_GETCHAIN),
+			Type:  nftMsgGetChain.HeaderType(),
 			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(table.Family), 0), cc.marshalAttr(attrs)...),
@@ -242,7 +242,7 @@ func (cc *Conn) ListChainsOfTableFamily(family TableFamily) ([]*Chain, error) {
 
 	msg := netlink.Message{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_GETCHAIN),
+			Type:  nftMsgGetChain.HeaderType(),
 			Flags: netlink.Request | netlink.Dump,
 		},
 		Data: extraHeader(uint8(family), 0),
@@ -267,8 +267,8 @@ func (cc *Conn) ListChainsOfTableFamily(family TableFamily) ([]*Chain, error) {
 }
 
 func chainFromMsg(msg netlink.Message) (*Chain, error) {
-	newChainHeaderType := netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWCHAIN)
-	delChainHeaderType := netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELCHAIN)
+	newChainHeaderType := nftMsgNewChain.HeaderType()
+	delChainHeaderType := nftMsgDelChain.HeaderType()
 	if got, want1, want2 := msg.Header.Type, newChainHeaderType, delChainHeaderType; got != want1 && got != want2 {
 		return nil, fmt.Errorf("unexpected header type: got %v, want %v or %v", got, want1, want2)
 	}

--- a/flowtable.go
+++ b/flowtable.go
@@ -25,14 +25,6 @@ import (
 
 const (
 	// not in ztypes_linux.go, added here
-	// https://cs.opensource.google/go/x/sys/+/c6bc011c:unix/ztypes_linux.go;l=1870-1892
-	NFT_MSG_NEWFLOWTABLE = 0x16
-	NFT_MSG_GETFLOWTABLE = 0x17
-	NFT_MSG_DELFLOWTABLE = 0x18
-)
-
-const (
-	// not in ztypes_linux.go, added here
 	// https://git.netfilter.org/libnftnl/tree/include/linux/netfilter/nf_tables.h?id=84d12cfacf8ddd857a09435f3d982ab6250d250c#n1634
 	_ = iota
 	NFTA_FLOWTABLE_TABLE
@@ -144,7 +136,7 @@ func (cc *Conn) AddFlowtable(f *Flowtable) *Flowtable {
 
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | NFT_MSG_NEWFLOWTABLE),
+			Type:  nftMsgNewFlowtable.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
 		},
 		Data: append(extraHeader(uint8(f.Table.Family), 0), data...),
@@ -164,7 +156,7 @@ func (cc *Conn) DelFlowtable(f *Flowtable) {
 
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | NFT_MSG_DELFLOWTABLE),
+			Type:  nftMsgDelFlowtable.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge,
 		},
 		Data: append(extraHeader(uint8(f.Table.Family), 0), data...),
@@ -207,7 +199,7 @@ func (cc *Conn) getFlowtables(t *Table) ([]netlink.Message, error) {
 
 	message := netlink.Message{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | NFT_MSG_GETFLOWTABLE),
+			Type:  nftMsgGetFlowtable.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge | netlink.Dump,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
@@ -226,7 +218,7 @@ func (cc *Conn) getFlowtables(t *Table) ([]netlink.Message, error) {
 }
 
 func ftsFromMsg(msg netlink.Message) (*Flowtable, error) {
-	flowHeaderType := netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | NFT_MSG_NEWFLOWTABLE)
+	flowHeaderType := nftMsgNewFlowtable.HeaderType()
 	if got, want := msg.Header.Type, flowHeaderType; got != want {
 		return nil, fmt.Errorf("unexpected header type: got %v, want %v", got, want)
 	}

--- a/gen.go
+++ b/gen.go
@@ -17,7 +17,7 @@ type Gen struct {
 // Deprecated: GenMsg is an inconsistent old name for Gen. Prefer using Gen.
 type GenMsg = Gen
 
-const genHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWGEN)
+var genHeaderType = nftMsgNewGen.HeaderType()
 
 func genFromMsg(msg netlink.Message) (*Gen, error) {
 	if got, want := msg.Header.Type, genHeaderType; got != want {
@@ -67,7 +67,7 @@ func (cc *Conn) GetGen() (*Gen, error) {
 
 	message := netlink.Message{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_GETGEN),
+			Type:  nftMsgGetGen.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge,
 		},
 		Data: append(extraHeader(0, 0), data...),

--- a/table.go
+++ b/table.go
@@ -23,13 +23,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	newTableHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWTABLE)
-	delTableHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELTABLE)
-
-	// FIXME: in sys@v0.34.0 no unix.NFT_MSG_DESTROYTABLE const yet.
-	// See nf_tables_msg_types enum in https://git.netfilter.org/nftables/tree/include/linux/netfilter/nf_tables.h
-	destroyTableHeaderType = netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | 0x1a)
+var (
+	newTableHeaderType     = nftMsgNewTable.HeaderType()
+	delTableHeaderType     = nftMsgDelTable.HeaderType()
+	destroyTableHeaderType = nftMsgDestroyTable.HeaderType()
 )
 
 // TableFamily specifies the address family for this table.
@@ -131,7 +128,7 @@ func (cc *Conn) addTable(t *Table, flag netlink.HeaderFlags) *Table {
 
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_NEWTABLE),
+			Type:  nftMsgNewTable.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge | flag,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
@@ -161,7 +158,7 @@ func (cc *Conn) FlushTable(t *Table) {
 	})
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELRULE),
+			Type:  nftMsgDelRule.HeaderType(),
 			Flags: netlink.Request | netlink.Acknowledge,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
@@ -216,7 +213,7 @@ func (cc *Conn) listTablesOfNameAndFamily(name string, family TableFamily) ([]*T
 
 	msg := netlink.Message{
 		Header: netlink.Header{
-			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_GETTABLE),
+			Type:  nftMsgGetTable.HeaderType(),
 			Flags: flags,
 		},
 		Data: data,

--- a/types.go
+++ b/types.go
@@ -1,0 +1,146 @@
+package nftables
+
+import (
+	"fmt"
+
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type nftMsgType uint16
+
+// See: https://github.com/torvalds/linux/blob/cbd2257dc96e3e46217540fcb095a757ffa20d96/include/uapi/linux/netfilter/nf_tables.h#L110
+const (
+	nftMsgNewTable nftMsgType = iota
+	nftMsgGetTable
+	nftMsgDelTable
+	nftMsgNewChain
+	nftMsgGetChain
+	nftMsgDelChain
+	nftMsgNewRule
+	nftMsgGetRule
+	nftMsgDelRule
+	nftMsgNewSet
+	nftMsgGetSet
+	nftMsgDelSet
+	nftMsgNewSetElem
+	nftMsgGetSetElem
+	nftMsgDelSetElem
+	nftMsgNewGen
+	nftMsgGetGen
+	nftMsgTrace
+	nftMsgNewObj
+	nftMsgGetObj
+	nftMsgDelObj
+	nftMsgGetObjReset
+	nftMsgNewFlowtable
+	nftMsgGetFlowtable
+	nftMsgDelFlowtable
+	nftMsgGetRuleReset
+	nftMsgDestroyTable
+	nftMsgDestroyChain
+	nftMsgDestroyRule
+	nftMsgDestroySet
+	nftMsgDestroySetElem
+	nftMsgDestroyObj
+	nftMsgDestroyFlowtable
+	nftMsgGetSetElemReset
+	nftMsgMax
+)
+
+func (t nftMsgType) String() string {
+	switch t {
+	case nftMsgNewTable:
+		return "NFT_MSG_NEWTABLE"
+	case nftMsgGetTable:
+		return "NFT_MSG_GETTABLE"
+	case nftMsgDelTable:
+		return "NFT_MSG_DELTABLE"
+	case nftMsgNewChain:
+		return "NFT_MSG_NEWCHAIN"
+	case nftMsgGetChain:
+		return "NFT_MSG_GETCHAIN"
+	case nftMsgDelChain:
+		return "NFT_MSG_DELCHAIN"
+	case nftMsgNewRule:
+		return "NFT_MSG_NEWRULE"
+	case nftMsgGetRule:
+		return "NFT_MSG_GETRULE"
+	case nftMsgDelRule:
+		return "NFT_MSG_DELRULE"
+	case nftMsgNewSet:
+		return "NFT_MSG_NEWSET"
+	case nftMsgGetSet:
+		return "NFT_MSG_GETSET"
+	case nftMsgDelSet:
+		return "NFT_MSG_DELSET"
+	case nftMsgNewSetElem:
+		return "NFT_MSG_NEWSETELEM"
+	case nftMsgGetSetElem:
+		return "NFT_MSG_GETSETELEM"
+	case nftMsgDelSetElem:
+		return "NFT_MSG_DELSETELEM"
+	case nftMsgNewGen:
+		return "NFT_MSG_NEWGEN"
+	case nftMsgGetGen:
+		return "NFT_MSG_GETGEN"
+	case nftMsgTrace:
+		return "NFT_MSG_TRACE"
+	case nftMsgNewObj:
+		return "NFT_MSG_NEWOBJ"
+	case nftMsgGetObj:
+		return "NFT_MSG_GETOBJ"
+	case nftMsgDelObj:
+		return "NFT_MSG_DELOBJ"
+	case nftMsgGetObjReset:
+		return "NFT_MSG_GETOBJ_RESET"
+	case nftMsgNewFlowtable:
+		return "NFT_MSG_NEWFLOWTABLE"
+	case nftMsgGetFlowtable:
+		return "NFT_MSG_GETFLOWTABLE"
+	case nftMsgDelFlowtable:
+		return "NFT_MSG_DELFLOWTABLE"
+	case nftMsgGetRuleReset:
+		return "NFT_MSG_GETRULE_RESET"
+	case nftMsgDestroyTable:
+		return "NFT_MSG_DESTROYTABLE"
+	case nftMsgDestroyChain:
+		return "NFT_MSG_DESTROYCHAIN"
+	case nftMsgDestroyRule:
+		return "NFT_MSG_DESTROYRULE"
+	case nftMsgDestroySet:
+		return "NFT_MSG_DESTROYSET"
+	case nftMsgDestroySetElem:
+		return "NFT_MSG_DESTROYSETELEM"
+	case nftMsgDestroyObj:
+		return "NFT_MSG_DESTROYOBJ"
+	case nftMsgDestroyFlowtable:
+		return "NFT_MSG_DESTROYFLOWTABLE"
+	case nftMsgGetSetElemReset:
+		return "NFT_MSG_GETSETELEM_RESET"
+	default:
+		return fmt.Sprintf("Unknown NftMsgType(0x%X)", uint16(t))
+	}
+}
+
+func (t nftMsgType) HeaderType() netlink.HeaderType {
+	return netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | uint16(t))
+}
+
+func (t nftMsgType) Ptr() *nftMsgType {
+	return &t
+}
+
+func parseNftMsgType(ht netlink.HeaderType) (*nftMsgType, error) {
+	subsys := (uint16(ht) >> 8) & 0xff
+	if subsys != unix.NFNL_SUBSYS_NFTABLES {
+		return nil, fmt.Errorf("not an nftables subsystem: %d", subsys)
+	}
+
+	msgType := uint16(ht) & 0xff
+	if msgType >= uint16(nftMsgMax) {
+		return nil, fmt.Errorf("invalid nftables message type: %d", msgType)
+	}
+
+	return nftMsgType(msgType).Ptr(), nil
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,106 @@
+package nftables
+
+import (
+	"testing"
+
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func TestParseNftMsgType(t *testing.T) {
+	var tests = []struct {
+		name           string
+		headerType     netlink.HeaderType
+		wantErr        bool
+		wantNftMsgType *nftMsgType
+		wantString     string
+	}{
+		{
+			name:           "InvalidSubsystem",
+			headerType:     netlink.HeaderType(unix.NFNL_SUBSYS_CTNETLINK << 8),
+			wantErr:        true,
+			wantNftMsgType: nil,
+			wantString:     "",
+		},
+		{
+			name:           "InvalidMsgType",
+			headerType:     netlink.HeaderType(unix.NFNL_SUBSYS_NFTABLES<<8 | uint16(nftMsgMax+1)),
+			wantErr:        true,
+			wantNftMsgType: nil,
+			wantString:     "",
+		},
+		{
+			name:           "NewTable",
+			headerType:     netlink.HeaderType(unix.NFNL_SUBSYS_NFTABLES<<8 | uint16(nftMsgNewTable)),
+			wantErr:        false,
+			wantNftMsgType: nftMsgNewTable.Ptr(),
+			wantString:     "NFT_MSG_NEWTABLE",
+		},
+		{
+			name:           "GetChain",
+			headerType:     netlink.HeaderType(unix.NFNL_SUBSYS_NFTABLES<<8 | uint16(nftMsgGetChain)),
+			wantErr:        false,
+			wantNftMsgType: nftMsgGetChain.Ptr(),
+			wantString:     "NFT_MSG_GETCHAIN",
+		},
+		{
+			name:           "DelSet",
+			headerType:     netlink.HeaderType(unix.NFNL_SUBSYS_NFTABLES<<8 | uint16(nftMsgDelSet)),
+			wantErr:        false,
+			wantNftMsgType: nftMsgDelSet.Ptr(),
+			wantString:     "NFT_MSG_DELSET",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNftMsgType(tt.headerType)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseHeaderType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && *got != *tt.wantNftMsgType {
+				t.Errorf("parseHeaderType() = %v, want %v", got, tt.wantNftMsgType)
+			}
+
+			if !tt.wantErr && got.String() != tt.wantString {
+				t.Errorf("nftMsgType.String() = %v, want %v", got.String(), tt.wantString)
+			}
+		})
+	}
+}
+
+func TestNftMsgHeaderType(t *testing.T) {
+	var tests = []struct {
+		name    string
+		msgType nftMsgType
+		want    netlink.HeaderType
+	}{
+		{
+			name:    "nftMsgNewTable",
+			msgType: nftMsgNewTable,
+			want:    netlink.HeaderType(unix.NFNL_SUBSYS_NFTABLES<<8 | uint16(nftMsgNewTable)),
+		},
+		{
+			name:    "nftMsgGetChain",
+			msgType: nftMsgGetChain,
+			want:    netlink.HeaderType(unix.NFNL_SUBSYS_NFTABLES<<8 | uint16(nftMsgGetChain)),
+		},
+		{
+			name:    "nftMsgDelSet",
+			msgType: nftMsgDelSet,
+			want:    netlink.HeaderType(unix.NFNL_SUBSYS_NFTABLES<<8 | uint16(nftMsgDelSet)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.msgType.HeaderType()
+			if got != tt.want {
+				t.Errorf("HeaderType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Associate netlink errors with the specific NFT operations that produced them.

- Add nftMsgType with a String() method to replace sys/unix constants
- Add handleReceiveError to match errors to their originating messages
- Add withOpError to assist in handling netlink.OpError values

This updates errors from:

    receive: netlink receive: no such file or directory

to:

    receive: NFT_MSG_NEWCHAIN: netlink receive: no such file or directory