### PR TITLE
Stop requesting ACKs

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -143,7 +143,7 @@ func (cc *Conn) AddChain(c *Chain) *Chain {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgNewChain.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
+			Flags: netlink.Request | netlink.Create,
 		},
 		Data: append(extraHeader(uint8(c.Table.Family), 0), data...),
 	})
@@ -164,7 +164,7 @@ func (cc *Conn) DelChain(c *Chain) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgDelChain.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(c.Table.Family), 0), data...),
 	})
@@ -182,7 +182,7 @@ func (cc *Conn) FlushChain(c *Chain) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgDelRule.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(c.Table.Family), 0), data...),
 	})

--- a/conn.go
+++ b/conn.go
@@ -431,7 +431,7 @@ func (cc *Conn) FlushRuleset() {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  netlink.HeaderType((unix.NFNL_SUBSYS_NFTABLES << 8) | unix.NFT_MSG_DELTABLE),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
+			Flags: netlink.Request | netlink.Create,
 		},
 		Data: extraHeader(0, 0),
 	})

--- a/flowtable.go
+++ b/flowtable.go
@@ -137,7 +137,7 @@ func (cc *Conn) AddFlowtable(f *Flowtable) *Flowtable {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgNewFlowtable.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
+			Flags: netlink.Request | netlink.Create,
 		},
 		Data: append(extraHeader(uint8(f.Table.Family), 0), data...),
 	})
@@ -157,7 +157,7 @@ func (cc *Conn) DelFlowtable(f *Flowtable) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgDelFlowtable.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(f.Table.Family), 0), data...),
 	})
@@ -200,7 +200,7 @@ func (cc *Conn) getFlowtables(t *Table) ([]netlink.Message, error) {
 	message := netlink.Message{
 		Header: netlink.Header{
 			Type:  nftMsgGetFlowtable.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Dump,
+			Flags: netlink.Request | netlink.Dump,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	}

--- a/gen.go
+++ b/gen.go
@@ -68,7 +68,7 @@ func (cc *Conn) GetGen() (*Gen, error) {
 	message := netlink.Message{
 		Header: netlink.Header{
 			Type:  nftMsgGetGen.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(0, 0), data...),
 	}

--- a/obj.go
+++ b/obj.go
@@ -127,7 +127,7 @@ func (cc *Conn) AddObj(o Obj) Obj {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgNewObj.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
+			Flags: netlink.Request | netlink.Create,
 		},
 		Data: append(extraHeader(uint8(o.family()), 0), cc.marshalAttr(attrs)...),
 	})
@@ -149,7 +149,7 @@ func (cc *Conn) DeleteObject(o Obj) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgDelObj.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(o.family()), 0), data...),
 	})
@@ -355,7 +355,7 @@ func (cc *Conn) getObjWithLegacyType(o Obj, t *Table, msgType nftMsgType, return
 	message := netlink.Message{
 		Header: netlink.Header{
 			Type:  msgType.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | flags,
+			Flags: netlink.Request | flags,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	}

--- a/rule.go
+++ b/rule.go
@@ -143,7 +143,7 @@ func (cc *Conn) getRules(t *Table, c *Chain, msgType nftMsgType, handle uint64) 
 		{Type: unix.NFTA_RULE_CHAIN, Data: []byte(c.Name + "\x00")},
 	}
 
-	var flags netlink.HeaderFlags = netlink.Request | netlink.Acknowledge | netlink.Dump
+	var flags netlink.HeaderFlags = netlink.Request | netlink.Dump
 
 	if handle != 0 {
 		attrs = append(attrs, netlink.Attribute{
@@ -151,7 +151,7 @@ func (cc *Conn) getRules(t *Table, c *Chain, msgType nftMsgType, handle uint64) 
 			Data: binaryutil.BigEndian.PutUint64(handle),
 		})
 
-		flags = netlink.Request | netlink.Acknowledge
+		flags = netlink.Request
 	}
 
 	data, err := netlink.MarshalAttributes(attrs)
@@ -242,13 +242,13 @@ func (cc *Conn) newRule(r *Rule, op ruleOperation) *Rule {
 	var ruleRef *Rule
 	switch op {
 	case operationAdd:
-		flags = netlink.Request | netlink.Acknowledge | netlink.Create | netlink.Echo | netlink.Append
+		flags = netlink.Request | netlink.Create | netlink.Echo | netlink.Append
 		ruleRef = r
 	case operationInsert:
-		flags = netlink.Request | netlink.Acknowledge | netlink.Create | netlink.Echo
+		flags = netlink.Request | netlink.Create | netlink.Echo
 		ruleRef = r
 	case operationReplace:
-		flags = netlink.Request | netlink.Acknowledge | netlink.Replace
+		flags = netlink.Request | netlink.Replace
 	}
 
 	if r.Position != 0 {
@@ -343,7 +343,7 @@ func (cc *Conn) DelRule(r *Rule) error {
 		cc.setErr(err)
 		return err
 	}
-	flags := netlink.Request | netlink.Acknowledge
+	flags := netlink.Request
 
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{

--- a/set.go
+++ b/set.go
@@ -466,7 +466,7 @@ func (cc *Conn) appendElemList(s *Set, vals []SetElement, msgType nftMsgType) er
 		cc.messages = append(cc.messages, netlinkMessage{
 			Header: netlink.Header{
 				Type:  msgType.HeaderType(),
-				Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
+				Flags: netlink.Request | netlink.Create,
 			},
 			Data: append(extraHeader(uint8(s.Table.Family), 0), cc.marshalAttr(message)...),
 		})
@@ -737,7 +737,7 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgNewSet.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Create,
+			Flags: netlink.Request | netlink.Create,
 		},
 		Data: append(extraHeader(uint8(s.Table.Family), 0), cc.marshalAttr(tableInfo)...),
 	})
@@ -762,7 +762,7 @@ func (cc *Conn) DelSet(s *Set) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgDelSet.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(s.Table.Family), 0), data...),
 	})
@@ -779,7 +779,7 @@ func (cc *Conn) FlushSet(s *Set) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgDelSetElem.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(s.Table.Family), 0), data...),
 	})
@@ -950,7 +950,7 @@ func (cc *Conn) GetSets(t *Table) ([]*Set, error) {
 	message := netlink.Message{
 		Header: netlink.Header{
 			Type:  nftMsgGetSet.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Dump,
+			Flags: netlink.Request | netlink.Dump,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	}
@@ -995,7 +995,7 @@ func (cc *Conn) GetSetByName(t *Table, name string) (*Set, error) {
 	message := netlink.Message{
 		Header: netlink.Header{
 			Type:  nftMsgGetSet.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	}
@@ -1040,7 +1040,7 @@ func (cc *Conn) GetSetElements(s *Set) ([]SetElement, error) {
 	message := netlink.Message{
 		Header: netlink.Header{
 			Type:  nftMsgGetSetElem.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | netlink.Dump,
+			Flags: netlink.Request | netlink.Dump,
 		},
 		Data: append(extraHeader(uint8(s.Table.Family), 0), data...),
 	}

--- a/table.go
+++ b/table.go
@@ -102,7 +102,7 @@ func (cc *Conn) delTable(t *Table, hdrType netlink.HeaderType) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  hdrType,
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	})
@@ -129,7 +129,7 @@ func (cc *Conn) addTable(t *Table, flag netlink.HeaderFlags) *Table {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgNewTable.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge | flag,
+			Flags: netlink.Request | flag,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	})
@@ -159,7 +159,7 @@ func (cc *Conn) FlushTable(t *Table) {
 	cc.messages = append(cc.messages, netlinkMessage{
 		Header: netlink.Header{
 			Type:  nftMsgDelRule.HeaderType(),
-			Flags: netlink.Request | netlink.Acknowledge,
+			Flags: netlink.Request,
 		},
 		Data: append(extraHeader(uint8(t.Family), 0), data...),
 	})


### PR DESCRIPTION
Since https://github.com/google/nftables/pull/330 and https://github.com/google/nftables/pull/334 were merged, I wonder whether we need to keep requesting an acknowledge for every message we send.

Skipping ACK requests improves runtime and memory usage for large Flush batches, as it reduces the number of required `recvmsg` calls.

The first error will still be reported via an acknowledge even if none are requested.

This also matches the behavior of nft userspace.

To validate this, I prepared a small stress test that inserts (math.MaxUint16 * 10) rules and then calls Flush. The test completed in 13.36s with ACKs enabled, versus 2.98s without ACKs.

A separate memory test focusing on Flush also showed noticeably lower usage when ACKs were not requested (see attached images).

<img width="1881" height="1215" alt="2025-11-07_with_acks" src="https://github.com/user-attachments/assets/8ec663cc-3d92-4bce-88c3-52d8cb1402fb" />
<img width="2518" height="1561" alt="2025-11-07_without_acks" src="https://github.com/user-attachments/assets/4df4d715-e6e0-48a7-b7c3-9d23c775eb94" />


