### PR TITLE
Add IntervalOpen field to SetElement

### DIFF
--- a/userdata/userdata.go
+++ b/userdata/userdata.go
@@ -52,6 +52,12 @@ const (
 	NFTNL_UDATA_SET_ELEM_FLAGS
 )
 
+// Set element userdata flags
+// https://git.netfilter.org/libnftnl/tree/include/libnftnl/udata.h?id=d36691a4ac486857fd437d3a9aa3701a073a9539#n71
+const (
+	NFTNL_UDATA_SET_ELEM_F_INTERVAL_OPEN uint32 = 0x01
+)
+
 func Append(udata []byte, typ Type, data []byte) []byte {
 	udata = append(udata, byte(typ), byte(len(data)))
 	udata = append(udata, data...)


### PR DESCRIPTION
IntervalOpen is a set element userdata flag indicating the element has no corresponding end value and represents an unbounded interval [start, ∞). This is used when adding elements with overflowing end values such as 255.255.255.254/31 or 0.0.0.0/0.