### PR TITLE
set: fix byte order metadata for host-endian types and map data

### DIFF
--- a/nftables_test.go
+++ b/nftables_test.go
@@ -6495,6 +6495,206 @@ func TestVmap(t *testing.T) {
 	}
 }
 
+func TestSetByteOrder(t *testing.T) {
+	// Verify that KEYBYTEORDER and DATABYTEORDER userdata are emitted correctly
+	// for sets and maps with host-endian (NativeEndian) and big-endian types.
+	//
+	// Bug context: the library previously hard-coded KEYBYTEORDER=2 (big-endian)
+	// for all anonymous/constant/interval sets, ignoring the actual key type.
+	// Host-endian types like mark and ifname need KEYBYTEORDER=1 for correct
+	// display in nft list ruleset on little-endian systems.
+	// Additionally, DATABYTEORDER was never emitted for maps, causing map data
+	// values (like marks) to display byte-swapped.
+
+	tests := []struct {
+		name    string
+		set     nftables.Set
+		element []nftables.SetElement
+		// wantUserData is the expected NFTA_SET_USERDATA content (TLV encoded).
+		// NFTNL_UDATA_SET_KEYBYTEORDER (type=0): 1=host-endian, 2=big-endian
+		// NFTNL_UDATA_SET_DATABYTEORDER (type=1): 1=host-endian, 2=big-endian
+		wantUserData []byte
+	}{
+		{
+			name: "anonymous set with big-endian key (inet_service) emits KEYBYTEORDER=2",
+			set: nftables.Set{
+				Anonymous: true,
+				Constant:  true,
+				KeyType:   nftables.TypeInetService,
+			},
+			element: []nftables.SetElement{
+				{Key: binaryutil.BigEndian.PutUint16(80)},
+			},
+			// type=0 len=4 value=2 (KEYBYTEORDER=big-endian)
+			wantUserData: []byte{0x00, 0x04, 0x02, 0x00, 0x00, 0x00},
+		},
+		{
+			name: "anonymous set with host-endian key (mark) emits KEYBYTEORDER=1",
+			set: nftables.Set{
+				Anonymous:    true,
+				Constant:     true,
+				KeyType:      nftables.TypeMark,
+				KeyByteOrder: binaryutil.NativeEndian,
+			},
+			element: []nftables.SetElement{
+				{Key: binaryutil.NativeEndian.PutUint32(1)},
+			},
+			// type=0 len=4 value=1 (KEYBYTEORDER=host-endian)
+			wantUserData: []byte{0x00, 0x04, 0x01, 0x00, 0x00, 0x00},
+		},
+		{
+			name: "named set with host-endian key emits KEYBYTEORDER=1",
+			set: nftables.Set{
+				Name:         "test-marks",
+				KeyType:      nftables.TypeMark,
+				KeyByteOrder: binaryutil.NativeEndian,
+			},
+			element: []nftables.SetElement{
+				{Key: binaryutil.NativeEndian.PutUint32(1)},
+			},
+			// type=0 len=4 value=1 (KEYBYTEORDER=host-endian)
+			wantUserData: []byte{0x00, 0x04, 0x01, 0x00, 0x00, 0x00},
+		},
+		{
+			name: "map with host-endian key and data emits both KEYBYTEORDER=1 and DATABYTEORDER=1",
+			set: nftables.Set{
+				Name:          "test-map",
+				KeyType:       nftables.TypeMark,
+				DataType:      nftables.TypeMark,
+				KeyByteOrder:  binaryutil.NativeEndian,
+				DataByteOrder: binaryutil.NativeEndian,
+				IsMap:         true,
+			},
+			element: []nftables.SetElement{
+				{
+					Key: binaryutil.NativeEndian.PutUint32(1),
+					Val: binaryutil.NativeEndian.PutUint32(2),
+				},
+			},
+			// type=0 len=4 value=1 (KEYBYTEORDER=host), type=1 len=4 value=1 (DATABYTEORDER=host)
+			wantUserData: []byte{
+				0x00, 0x04, 0x01, 0x00, 0x00, 0x00,
+				0x01, 0x04, 0x01, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "named map without explicit KeyByteOrder emits only DATABYTEORDER=1",
+			set: nftables.Set{
+				Name:          "test-map",
+				KeyType:       nftables.TypeInetService,
+				DataType:      nftables.TypeMark,
+				DataByteOrder: binaryutil.NativeEndian,
+				IsMap:         true,
+			},
+			element: []nftables.SetElement{
+				{
+					Key: binaryutil.BigEndian.PutUint16(22),
+					Val: binaryutil.NativeEndian.PutUint32(1),
+				},
+			},
+			// No KEYBYTEORDER (named, non-anonymous/interval, no explicit KeyByteOrder)
+			// type=1 len=4 value=1 (DATABYTEORDER=host)
+			wantUserData: []byte{
+				0x01, 0x04, 0x01, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "anonymous map with big-endian key and host-endian data emits KEYBYTEORDER=2 and DATABYTEORDER=1",
+			set: nftables.Set{
+				Anonymous:     true,
+				Constant:      true,
+				KeyType:       nftables.TypeInetService,
+				DataType:      nftables.TypeMark,
+				DataByteOrder: binaryutil.NativeEndian,
+				IsMap:         true,
+			},
+			element: []nftables.SetElement{
+				{
+					Key: binaryutil.BigEndian.PutUint16(22),
+					Val: binaryutil.NativeEndian.PutUint32(1),
+				},
+			},
+			// type=0 len=4 value=2 (KEYBYTEORDER=big), type=1 len=4 value=1 (DATABYTEORDER=host)
+			wantUserData: []byte{
+				0x00, 0x04, 0x02, 0x00, 0x00, 0x00,
+				0x01, 0x04, 0x01, 0x00, 0x00, 0x00,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured []netlink.Message
+			c, err := nftables.New(nftables.WithTestDial(func(req []netlink.Message) ([]netlink.Message, error) {
+				captured = append(captured, req...)
+				return nil, nil
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			filter := c.AddTable(&nftables.Table{
+				Family: nftables.TableFamilyIPv4,
+				Name:   "filter",
+			})
+
+			tt.set.Table = filter
+			if err := c.AddSet(&tt.set, tt.element); err != nil {
+				t.Fatalf("c.AddSet() failed: %v", err)
+			}
+
+			if err := c.Flush(); err != nil {
+				t.Fatalf("c.Flush() failed: %v", err)
+			}
+
+			// Find the NFTA_SET_USERDATA attribute (type 0x0d) in captured messages.
+			// The attribute uses standard netlink TLV: 2-byte length, 2-byte type, then data.
+			const nftaSetUserData = 0x0d
+			var foundUserData []byte
+			for _, msg := range captured {
+				b, err := msg.MarshalBinary()
+				if err != nil {
+					continue
+				}
+				// Skip netlink header (16 bytes) and nfgenmsg (4 bytes)
+				if len(b) < 20 {
+					continue
+				}
+				attrs := b[20:]
+				// Walk netlink attributes looking for type 0x0d
+				for len(attrs) >= 4 {
+					aLen := int(attrs[0]) | int(attrs[1])<<8
+					aType := int(attrs[2]) | int(attrs[3])<<8
+					if aLen < 4 || aLen > len(attrs) {
+						break
+					}
+					if aType == nftaSetUserData {
+						foundUserData = attrs[4:aLen]
+						break
+					}
+					// Align to 4 bytes
+					aLen = (aLen + 3) &^ 3
+					if aLen > len(attrs) {
+						break
+					}
+					attrs = attrs[aLen:]
+				}
+				if foundUserData != nil {
+					break
+				}
+			}
+
+			if foundUserData == nil {
+				t.Fatal("NFTA_SET_USERDATA attribute not found in captured messages")
+			}
+
+			if !bytes.Equal(foundUserData, tt.wantUserData) {
+				t.Errorf("userdata mismatch:\n  got:  %x\n  want: %x", foundUserData, tt.wantUserData)
+			}
+		})
+	}
+}
+
 func TestJHash(t *testing.T) {
 	// The want byte sequences come from stracing nft(8), e.g.:
 	// strace -f -v -x -s 2048 -eraw=sendto nft add rule filter prerouting mark set jhash ip saddr mod 2

--- a/set.go
+++ b/set.go
@@ -267,8 +267,9 @@ type Set struct {
 	DataType      SetDatatype
 	// Either host (binaryutil.NativeEndian) or big (binaryutil.BigEndian) endian as per
 	// https://git.netfilter.org/nftables/tree/include/datatype.h?id=d486c9e626405e829221b82d7355558005b26d8a#n109
-	KeyByteOrder binaryutil.ByteOrder
-	Comment      string
+	KeyByteOrder  binaryutil.ByteOrder
+	DataByteOrder binaryutil.ByteOrder
+	Comment       string
 	// Indicates that the set has "size" specifier
 	Size uint32
 }
@@ -716,12 +717,27 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	// https://git.netfilter.org/libnftnl/tree/include/udata.h#n17
 	var userData []byte
 
-	if s.Anonymous || s.Constant || s.Interval || s.KeyByteOrder == binaryutil.BigEndian {
-		// Semantically useless - kept for binary compatability with nft
-		userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_KEYBYTEORDER, 2)
-	} else if s.KeyByteOrder == binaryutil.NativeEndian {
+	// Emit KEYBYTEORDER metadata matching nft C tool behavior (mnl.c:mnl_nft_set_add).
+	// Anonymous, constant, and interval sets always need byte order metadata.
+	// When KeyByteOrder is explicitly set, use it; otherwise default to big-endian
+	// for backward compatibility with prior library behavior.
+	if s.KeyByteOrder == binaryutil.NativeEndian {
 		// Per https://git.netfilter.org/nftables/tree/src/mnl.c?id=187c6d01d35722618c2711bbc49262c286472c8f#n1165
 		userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_KEYBYTEORDER, 1)
+	} else if s.Anonymous || s.Constant || s.Interval || s.KeyByteOrder == binaryutil.BigEndian {
+		userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_KEYBYTEORDER, 2)
+	}
+
+	// Emit DATABYTEORDER for maps, matching nft C tool behavior (mnl.c:mnl_nft_set_add).
+	// Without this, nft list ruleset cannot determine the data byte order and displays
+	// host-endian values (like marks) as byte-swapped on LE systems.
+	if s.IsMap {
+		switch s.DataByteOrder {
+		case binaryutil.NativeEndian:
+			userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_DATABYTEORDER, 1)
+		case binaryutil.BigEndian:
+			userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_DATABYTEORDER, 2)
+		}
 	}
 
 	if s.Interval && s.AutoMerge {


### PR DESCRIPTION
Fix two issues with set/map userdata byte order metadata that cause `nft list ruleset` to misinterpret element keys and data values on little-endian systems. The kernel-level data is always correct — these are display/round-trip issues affecting the userdata TLVs that the `nft` CLI uses to reconstruct human-readable output.

## Bug 1: Anonymous sets ignore explicit `KeyByteOrder`

Anonymous/constant/interval sets unconditionally emit `KEYBYTEORDER=2` (big-endian), ignoring the `KeyByteOrder` field. The `nft` C tool always uses the key expression's actual byte order ([`mnl.c:mnl_nft_set_add`](https://git.netfilter.org/nftables/tree/src/mnl.c?id=187c6d01d35722618c2711bbc49262c286472c8f#n1165)), not a blanket default.

For host-endian types like `mark_type` (`BYTEORDER_HOST_ENDIAN`) and `ifname_type` (`BYTEORDER_HOST_ENDIAN`), this causes `nft list ruleset` to misinterpret the element data on LE systems:

- **Mark sets**: `meta mark { 0x00000000, 0x01000000 }` instead of `{ 0x00000000, 0x00000001 }`
- **Interface name vmaps**: `iifname vmap { "" : jump chain1 }` instead of `{ "eth0" : jump chain1 }`

The existing comment "Semantically useless - kept for binary compatability with nft" is incorrect — `KEYBYTEORDER` IS semantically meaningful for host-endian types. The `nft` C tool uses it in [`netlink_delinearize_setelem`](https://git.netfilter.org/nftables/tree/src/netlink.c) to decide whether to call `mpz_switch_byteorder` on element keys.

**Fix**: When the anonymous/constant/interval condition fires, check if `KeyByteOrder` is explicitly set to `NativeEndian` and emit `1` (host) instead of `2` (big). Falls back to the original big-endian default when `KeyByteOrder` is unset (zero value), preserving backwards compatibility.

## Bug 2: Maps never emit `DATABYTEORDER`

The `NFTNL_UDATA_SET_DATABYTEORDER` constant exists in `userdata.go` but is never used. The `Set` struct has no `DataByteOrder` field, and the userdata construction has no code path that emits this TLV.

The `nft` C tool [emits `DATABYTEORDER`](https://git.netfilter.org/nftables/tree/src/mnl.c?id=187c6d01d35722618c2711bbc49262c286472c8f#n1169) for all datamaps:

```c
if (set_is_datamap(set->flags))
    nftnl_udata_put_u32(udbuf, NFTNL_UDATA_SET_DATABYTEORDER,
                         set->data->byteorder);
```

Without it, `nft list ruleset` uses `BYTEORDER_INVALID` for map data, skips the `mpz_switch_byteorder` call, and displays native-endian values as byte-swapped on LE systems:

```
# Expected:
elements = { ... : 0x00000001 }

# Without DATABYTEORDER on LE:
elements = { ... : 0x01000000 }
```

**Fix**: Add `DataByteOrder` field to `Set` struct and emit `NFTNL_UDATA_SET_DATABYTEORDER` in the userdata construction for maps when set.

## Discovery context

Found while debugging a WireGuard mesh overlay that uses `meta mark` sets and maps for zone-based connection latching. The incorrect display made it extremely difficult to diagnose whether mark values were being set correctly, since `nft list ruleset` showed byte-swapped values but the kernel data was actually correct (verified via `nft --debug=netlink list ruleset`).

## Testing

Verified on linux/arm64 (little-endian) that after this patch:
- Anonymous `TypeMark` sets display correct values (`0x00000001` not `0x01000000`)
- Map data with `TypeMark` displays correct values
- `nft --debug=netlink list ruleset` shows identical kernel-level bytes before and after (no functional change)
- `GOOS=linux go build .` and `GOOS=linux go vet .` pass cleanly