### PR TITLE
set: fix byte order metadata for host-endian types and map data

### DIFF
--- a/nftables_test.go
+++ b/nftables_test.go
@@ -3742,6 +3742,144 @@ func TestCreateAutoMergeSet(t *testing.T) {
 	}
 }
 
+func TestSetByteOrderRoundTrip(t *testing.T) {
+	tests := []struct {
+		name          string
+		set           nftables.Set
+		elems         []nftables.SetElement
+		wantKeyOrder  binaryutil.ByteOrder
+		wantDataOrder binaryutil.ByteOrder
+	}{
+		{
+			name: "constant set defaults key byteorder to big-endian",
+			set: nftables.Set{
+				Constant: true,
+				KeyType:  nftables.TypeInetService,
+			},
+			elems: []nftables.SetElement{
+				{Key: binaryutil.BigEndian.PutUint16(80)},
+			},
+			wantKeyOrder: binaryutil.BigEndian,
+		},
+		{
+			name: "explicit host-endian key byteorder",
+			set: nftables.Set{
+				KeyType:      nftables.TypeMark,
+				KeyByteOrder: binaryutil.NativeEndian,
+			},
+			elems: []nftables.SetElement{
+				{Key: binaryutil.NativeEndian.PutUint32(1)},
+			},
+			wantKeyOrder: binaryutil.NativeEndian,
+		},
+		{
+			name: "interval set defaults key byteorder to big-endian",
+			set: nftables.Set{
+				Interval: true,
+				KeyType:  nftables.TypeInetService,
+			},
+			wantKeyOrder: binaryutil.BigEndian,
+		},
+		{
+			name: "interval set with explicit host-endian key byteorder",
+			set: nftables.Set{
+				Interval:     true,
+				KeyType:      nftables.TypeMark,
+				KeyByteOrder: binaryutil.NativeEndian,
+			},
+			elems: []nftables.SetElement{
+				{Key: binaryutil.NativeEndian.PutUint32(7)},
+			},
+			wantKeyOrder: binaryutil.NativeEndian,
+		},
+		{
+			name: "map with explicit host-endian key and data byteorder",
+			set: nftables.Set{
+				KeyType:       nftables.TypeMark,
+				DataType:      nftables.TypeMark,
+				KeyByteOrder:  binaryutil.NativeEndian,
+				DataByteOrder: binaryutil.NativeEndian,
+				IsMap:         true,
+			},
+			elems: []nftables.SetElement{
+				{
+					Key: binaryutil.NativeEndian.PutUint32(1),
+					Val: binaryutil.NativeEndian.PutUint32(2),
+				},
+			},
+			wantKeyOrder:  binaryutil.NativeEndian,
+			wantDataOrder: binaryutil.NativeEndian,
+		},
+		{
+			name: "map with explicit data byteorder only",
+			set: nftables.Set{
+				KeyType:       nftables.TypeInetService,
+				DataType:      nftables.TypeMark,
+				DataByteOrder: binaryutil.NativeEndian,
+				IsMap:         true,
+			},
+			elems: []nftables.SetElement{
+				{
+					Key: binaryutil.BigEndian.PutUint16(22),
+					Val: binaryutil.NativeEndian.PutUint32(1),
+				},
+			},
+			wantDataOrder: binaryutil.NativeEndian,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, newNS := nftest.OpenSystemConn(t, *enableSysTests)
+			defer nftest.CleanupSystemConn(t, newNS)
+			defer conn.FlushRuleset()
+
+			table := conn.AddTable(&nftables.Table{
+				Name:   fmt.Sprintf("byteorder-table-%d", i),
+				Family: nftables.TableFamilyIPv4,
+			})
+
+			set := tt.set
+			set.Table = table
+			set.Name = fmt.Sprintf("byteorder-set-%d", i)
+
+			if err := conn.AddSet(&set, tt.elems); err != nil {
+				t.Fatalf("failed to add set: %v", err)
+			}
+			if err := conn.Flush(); err != nil {
+				t.Fatalf("failed to flush: %v", err)
+			}
+
+			gotSet, err := conn.GetSetByName(table, set.Name)
+			if err != nil {
+				t.Fatalf("failed to find set %q: %v", set.Name, err)
+			}
+			if gotSet.KeyByteOrder != tt.wantKeyOrder {
+				t.Fatalf("set.KeyByteOrder = %v, want %v", gotSet.KeyByteOrder, tt.wantKeyOrder)
+			}
+			if gotSet.DataByteOrder != tt.wantDataOrder {
+				t.Fatalf("set.DataByteOrder = %v, want %v", gotSet.DataByteOrder, tt.wantDataOrder)
+			}
+
+			gotElems, err := conn.GetSetElements(gotSet)
+			if err != nil {
+				t.Fatalf("failed to get set elements: %v", err)
+			}
+			if got, want := len(gotElems), len(tt.elems); got != want {
+				t.Fatalf("got %d elements, want %d", got, want)
+			}
+			for i := range tt.elems {
+				if !bytes.Equal(gotElems[i].Key, tt.elems[i].Key) {
+					t.Fatalf("element[%d].Key = %x, want %x", i, gotElems[i].Key, tt.elems[i].Key)
+				}
+				if !bytes.Equal(gotElems[i].Val, tt.elems[i].Val) {
+					t.Fatalf("element[%d].Val = %x, want %x", i, gotElems[i].Val, tt.elems[i].Val)
+				}
+			}
+		})
+	}
+}
+
 func TestIP6SetAddElements(t *testing.T) {
 	// Create a new network namespace to test these operations,
 	// and tear down the namespace at test completion.

--- a/set.go
+++ b/set.go
@@ -267,8 +267,9 @@ type Set struct {
 	DataType      SetDatatype
 	// Either host (binaryutil.NativeEndian) or big (binaryutil.BigEndian) endian as per
 	// https://git.netfilter.org/nftables/tree/include/datatype.h?id=d486c9e626405e829221b82d7355558005b26d8a#n109
-	KeyByteOrder binaryutil.ByteOrder
-	Comment      string
+	KeyByteOrder  binaryutil.ByteOrder
+	DataByteOrder binaryutil.ByteOrder
+	Comment       string
 	// Indicates that the set has "size" specifier
 	Size uint32
 }
@@ -716,12 +717,27 @@ func (cc *Conn) AddSet(s *Set, vals []SetElement) error {
 	// https://git.netfilter.org/libnftnl/tree/include/udata.h#n17
 	var userData []byte
 
-	if s.Anonymous || s.Constant || s.Interval || s.KeyByteOrder == binaryutil.BigEndian {
-		// Semantically useless - kept for binary compatability with nft
-		userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_KEYBYTEORDER, 2)
-	} else if s.KeyByteOrder == binaryutil.NativeEndian {
+	// Emit KEYBYTEORDER metadata matching nft C tool behavior (mnl.c:mnl_nft_set_add).
+	// Anonymous, constant, and interval sets always need byte order metadata.
+	// When KeyByteOrder is explicitly set, use it; otherwise default to big-endian
+	// for backward compatibility with prior library behavior.
+	if s.KeyByteOrder == binaryutil.NativeEndian {
 		// Per https://git.netfilter.org/nftables/tree/src/mnl.c?id=187c6d01d35722618c2711bbc49262c286472c8f#n1165
 		userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_KEYBYTEORDER, 1)
+	} else if s.Anonymous || s.Constant || s.Interval || s.KeyByteOrder == binaryutil.BigEndian {
+		userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_KEYBYTEORDER, 2)
+	}
+
+	// Emit DATABYTEORDER for maps, matching nft C tool behavior (mnl.c:mnl_nft_set_add).
+	// Without this, nft list ruleset cannot determine the data byte order and displays
+	// host-endian values (like marks) as byte-swapped on LE systems.
+	if s.IsMap {
+		switch s.DataByteOrder {
+		case binaryutil.NativeEndian:
+			userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_DATABYTEORDER, 1)
+		case binaryutil.BigEndian:
+			userData = userdata.AppendUint32(userData, userdata.NFTNL_UDATA_SET_DATABYTEORDER, 2)
+		}
 	}
 
 	if s.Interval && s.AutoMerge {
@@ -862,6 +878,12 @@ func setsFromMsg(msg netlink.Message) (*Set, error) {
 			set.DataType.Bytes = binary.BigEndian.Uint32(ad.Bytes())
 		case unix.NFTA_SET_USERDATA:
 			data := ad.Bytes()
+			if val, ok := userdata.GetUint32(data, userdata.NFTNL_UDATA_SET_KEYBYTEORDER); ok {
+				set.KeyByteOrder = parseSetByteOrder(val)
+			}
+			if val, ok := userdata.GetUint32(data, userdata.NFTNL_UDATA_SET_DATABYTEORDER); ok {
+				set.DataByteOrder = parseSetByteOrder(val)
+			}
 			if val, ok := userdata.GetString(data, userdata.NFTNL_UDATA_SET_COMMENT); ok {
 				set.Comment = val
 			}
@@ -889,6 +911,17 @@ func setsFromMsg(msg netlink.Message) (*Set, error) {
 		}
 	}
 	return &set, nil
+}
+
+func parseSetByteOrder(v uint32) binaryutil.ByteOrder {
+	switch v {
+	case 1:
+		return binaryutil.NativeEndian
+	case 2:
+		return binaryutil.BigEndian
+	default:
+		return nil
+	}
 }
 
 func parseSetDatatype(magic uint32) (SetDatatype, error) {


### PR DESCRIPTION
Fix two issues with set/map userdata byte order metadata that cause `nft list ruleset` to misinterpret element keys and data values on little-endian systems. The kernel-level data is always correct — these are display/round-trip issues affecting the userdata TLVs that the `nft` CLI uses to reconstruct human-readable output.

## Bug 1: Anonymous sets ignore explicit `KeyByteOrder`

Anonymous/constant/interval sets unconditionally emit `KEYBYTEORDER=2` (big-endian), ignoring the `KeyByteOrder` field. The `nft` C tool always uses the key expression's actual byte order ([`mnl.c:mnl_nft_set_add`](https://git.netfilter.org/nftables/tree/src/mnl.c?id=187c6d01d35722618c2711bbc49262c286472c8f#n1165)), not a blanket default.

For host-endian types like `mark_type` (`BYTEORDER_HOST_ENDIAN`) and `ifname_type` (`BYTEORDER_HOST_ENDIAN`), this causes `nft list ruleset` to misinterpret the element data on LE systems:

- **Mark sets**: `meta mark { 0x00000000, 0x01000000 }` instead of `{ 0x00000000, 0x00000001 }`
- **Interface name vmaps**: `iifname vmap { "" : jump chain1 }` instead of `{ "eth0" : jump chain1 }`

The existing comment "Semantically useless - kept for binary compatability with nft" is incorrect — `KEYBYTEORDER` IS semantically meaningful for host-endian types. The `nft` C tool uses it in [`netlink_delinearize_setelem`](https://git.netfilter.org/nftables/tree/src/netlink.c) to decide whether to call `mpz_switch_byteorder` on element keys.

**Fix**: When the anonymous/constant/interval condition fires, check if `KeyByteOrder` is explicitly set to `NativeEndian` and emit `1` (host) instead of `2` (big). Falls back to the original big-endian default when `KeyByteOrder` is unset (zero value), preserving backwards compatibility.

## Bug 2: Maps never emit `DATABYTEORDER`

The `NFTNL_UDATA_SET_DATABYTEORDER` constant exists in `userdata.go` but is never used. The `Set` struct has no `DataByteOrder` field, and the userdata construction has no code path that emits this TLV.

The `nft` C tool [emits `DATABYTEORDER`](https://git.netfilter.org/nftables/tree/src/mnl.c?id=187c6d01d35722618c2711bbc49262c286472c8f#n1169) for all datamaps:

```c
if (set_is_datamap(set->flags))
    nftnl_udata_put_u32(udbuf, NFTNL_UDATA_SET_DATABYTEORDER,
                         set->data->byteorder);
```

Without it, `nft list ruleset` uses `BYTEORDER_INVALID` for map data, skips the `mpz_switch_byteorder` call, and displays native-endian values as byte-swapped on LE systems:

```
# Expected:
elements = { ... : 0x00000001 }

# Without DATABYTEORDER on LE:
elements = { ... : 0x01000000 }
```

**Fix**: Add `DataByteOrder` field to `Set` struct and emit `NFTNL_UDATA_SET_DATABYTEORDER` in the userdata construction for maps when set.

## Discovery context

Found while debugging a WireGuard mesh overlay that uses `meta mark` sets and maps for zone-based connection latching. The incorrect display made it extremely difficult to diagnose whether mark values were being set correctly, since `nft list ruleset` showed byte-swapped values but the kernel data was actually correct (verified via `nft --debug=netlink list ruleset`).

## Testing

Verified on linux/arm64 (little-endian) that after this patch:
- Anonymous `TypeMark` sets display correct values (`0x00000001` not `0x01000000`)
- Map data with `TypeMark` displays correct values
- `nft --debug=netlink list ruleset` shows identical kernel-level bytes before and after (no functional change)
- `GOOS=linux go build .` and `GOOS=linux go vet .` pass cleanly