### PR TITLE
expr: support directional conntrack zone assignment

### DIFF
--- a/expr/ct.go
+++ b/expr/ct.go
@@ -172,7 +172,7 @@ func (e *Ct) marshalData(fam byte) ([]byte, error) {
 	exprData = append(exprData, regData...)
 
 	switch e.Key {
-	case CtKeyPKTS, CtKeyBYTES, CtKeyAVGPKT, CtKeyL3PROTOCOL, CtKeyPROTOCOL:
+	case CtKeyPKTS, CtKeyBYTES, CtKeyAVGPKT, CtKeyL3PROTOCOL, CtKeyPROTOCOL, CtKeyZONE:
 		if !e.OptDirection {
 			break
 		}
@@ -217,7 +217,7 @@ func (e *Ct) unmarshal(fam byte, data []byte) error {
 	}
 
 	switch e.Key {
-	case CtKeyPKTS, CtKeyBYTES, CtKeyAVGPKT, CtKeyL3PROTOCOL, CtKeyPROTOCOL:
+	case CtKeyPKTS, CtKeyBYTES, CtKeyAVGPKT, CtKeyL3PROTOCOL, CtKeyPROTOCOL, CtKeyZONE:
 		e.OptDirection = hasDirection
 	}
 


### PR DESCRIPTION
The kernel accepts `NFTA_CT_DIRECTION` for `NFT_CT_ZONE` on the set path (since 4.10), which is what makes per-direction zone assignment like `ct original zone set 1` expressible. `Ct` only marshals the direction attribute for the address/proto keys and (opt-in via `OptDirection`) the counter keys, so directional zone assignment cannot be programmed through this library today.

This extends the existing `OptDirection` opt-in to `CtKeyZONE` (two case-list additions). The zero value stays backward compatible: without the flag the attribute is omitted and the zone applies to both directions, exactly as before.

Directional zones are the standard way to NAT overlapping source networks: the zone is assigned on the original direction only, so reply lookups resolve in the default zone via the unique SNAT tuple. Verified against a live kernel: rules programmed with `OptDirection: true` render as `ct original zone set 1` in `nft list ruleset`, and the bidirectional form is unchanged.